### PR TITLE
Collection framework, ReportBuilder, reusable styles, beginner examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,31 @@ These two are the simplest possible starting points — a title, a few cells, an
 
 ---
 
+#### 🛒 Rows from arrays — one call writes the whole row
+
+<p align="center">
+  <img src="docs/row-array-preview.svg" alt="Shopping list produced by RowFromArrayExample.java" width="90%"/>
+</p>
+
+> Source: [`examples/RowFromArrayExample.java`](examples/RowFromArrayExample.java) ·
+> Showcases:
+>
+> ```java
+> // Header row from a String[]
+> String[] headers = {"Item", "Qty", "Unit", "Aisle"};
+> sh.row(2).setRowValues(headers);
+>
+> // Data rows from Object[] — mixed types get routed automatically
+> sh.row(3).setValues(new Object[]{"Apples",  6, "pcs", "Produce"});
+> sh.row(4).setValues(new Object[]{"Milk",    2, "L",   "Dairy"});
+> ```
+>
+> No per-cell loop, no column-index bookkeeping. Use `setRowValues(String[])` when
+> every cell is text (headers are the classic case) and `setValues(Object[])` when
+> the row mixes strings, numbers, dates, booleans, etc.
+
+---
+
 ### 🟠 For intermediate + advanced users
 
 The rest use `@ExcelColumn` bean mapping, `ReportBuilder`, formulas, hyperlinks, round-trip reads, etc.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ Every example below is a real file under [`examples/`](examples) that you can ru
 `mvn compile exec:java -Dexec.mainClass=<className>`. Each screenshot is a faithful
 mock of the workbook it produces — colours, zebra, freeze pane, auto-filter, and all.
 
+### 🟢 For beginners — no beans, no annotations
+
+These two are the simplest possible starting points — a title, a few cells, and one built-in style preset.
+
+#### 📝 Title and content — the simplest possible styled sheet
+
+<p align="center">
+  <img src="docs/title-content-preview.svg" alt="Title + content produced by TitleAndContentExample.java" width="80%"/>
+</p>
+
+> Source: [`examples/TitleAndContentExample.java`](examples/TitleAndContentExample.java) ·
+> Showcases: a merged title row · the `ExcelStyle.header()` preset · plain text rows · `autoSizeAllColumns()`.
+> **No beans, no loops, no annotations — about 15 lines of logic.**
+
+---
+
+#### 📊 KPI tiles — 4 colour-coded summary tiles on one sheet
+
+<p align="center">
+  <img src="docs/kpi-preview.svg" alt="KPIs produced by KpiTilesExample.java" width="90%"/>
+</p>
+
+> Source: [`examples/KpiTilesExample.java`](examples/KpiTilesExample.java) ·
+> Showcases: custom fill colours per tile (green / blue / orange / red) · a small helper method for reuse.
+> A beginner-sized slice of what [`DashboardExample`](examples/DashboardExample.java) does on sheet 1.
+
+---
+
+### 🟠 For intermediate + advanced users
+
+The rest use `@ExcelColumn` bean mapping, `ReportBuilder`, formulas, hyperlinks, round-trip reads, etc.
+
 ### 📦 Invoice — merged title · address blocks · line items · formulas · totals
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,219 +1,325 @@
 # Excel 📈
 
 <div align="center">
-  <em>A powerful and easy-to-use Java library for Excel file manipulation</em>
-  <br><br>
 
-  [![CI & Release](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml/badge.svg)](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml)
-  [![codecov](https://codecov.io/gh/Bismi-Solutions/Excel/branch/master/graph/badge.svg)](https://codecov.io/gh/Bismi-Solutions/Excel)
-  [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Bismi-Solutions_Excel&metric=alert_status)](https://sonarcloud.io/project/overview?id=Bismi-Solutions_Excel)
-  [![Known Vulnerabilities](https://snyk.io/test/github/Bismi-Solutions/Excel/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/Bismi-Solutions/Excel?targetFile=pom.xml)
-  [![Maven Central](https://img.shields.io/maven-central/v/solutions.bismi.excel/excel.svg)](https://search.maven.org/artifact/solutions.bismi.excel/excel)
-  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-  [![Java Version](https://img.shields.io/badge/Java-17%2B-blue)](https://openjdk.java.net/)
+<h3><em>Ship a styled Excel report in 5 lines — skip the 60 lines of Apache POI boilerplate.</em></h3>
+
+[![CI & Release](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml/badge.svg)](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Bismi-Solutions/Excel/branch/master/graph/badge.svg)](https://codecov.io/gh/Bismi-Solutions/Excel)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Bismi-Solutions_Excel&metric=alert_status)](https://sonarcloud.io/project/overview?id=Bismi-Solutions_Excel)
+[![Known Vulnerabilities](https://snyk.io/test/github/Bismi-Solutions/Excel/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/Bismi-Solutions/Excel?targetFile=pom.xml)
+[![Maven Central](https://img.shields.io/maven-central/v/solutions.bismi.excel/excel.svg)](https://search.maven.org/artifact/solutions.bismi.excel/excel)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Java Version](https://img.shields.io/badge/Java-17%2B-blue)](https://openjdk.java.net/)
+
 </div>
 
-## 🚀  Why *Excel*?
+```java
+ReportBuilder.on(sheet)
+    .title("Q3 Sales Report")
+    .rowsFromBeans(products)      // ← your List<Bean>
+    .zebraStripes(true).freezeHeader(true).autoFilter(true)
+    .render();
+```
 
-Apache POI is wonderfully complete—but you pay in verbosity. *Excel* wraps POI with a **fluent, COM‑style API** so you can:
+**Result:**
 
-- Build a workbook in **two lines**:
-  ```java
-  ExcelApplication app = new ExcelApplication();
-  ExcelWorkBook wb = app.createWorkBook("hello.xlsx");
-  ExcelWorkSheet sh = wb.addSheet("Hi");
-  sh.cell(1,1).setText("👋");
-  sh.saveWorkBook();
-  app.closeAllWorkBooks();
-  ```
-- Use named or hex colours, borders, number‑formats, merges & formulas without memorising POI constants.
-- Keep full access to the underlying POI objects when you need edge‑case power.
-
-Works unchanged on Windows 🪟, macOS 🍎 and Linux 🐧 (Java 17 +).
+<p align="center">
+  <img src="docs/report-preview.svg" alt="Styled Excel report generated in 5 lines" width="100%"/>
+</p>
 
 ---
 
-## 📦 Installation (copy & go)
+## 🤔 Why *Excel*, not Apache POI directly?
 
-Choose the snippet for your build tool and you're done.
+POI is powerful — and verbose. Every styled cell forces you through the same choreography: `CreationHelper` → `CellStyle.cloneStyleFrom` → `DataFormat` → `Font` → manual type dispatch (`setCellValue(String)` vs `setCellValue(double)` vs `setCellValue(Date)`) → `CellRangeAddress` → `createFreezePane` → `setAutoFilter`.
 
-### Maven
+Most business-Excel tasks boil down to **"take a list of objects and make it look like a report."** *Excel* gives you **one call** for that, while still exposing the POI workbook for edge cases.
 
-```xml
-<dependency>
-  <groupId>solutions.bismi.excel</groupId>
-  <artifactId>excel</artifactId>
-  <version>1.1.12</version>
-</dependency>
-```
+### What you skip
 
-### Gradle (Groovy DSL)
+| You no longer juggle | Because *Excel* handles it |
+|---|---|
+| Creating/cloning `CellStyle` for every cell | `ExcelStyle` — build once, apply everywhere |
+| Hitting POI's **64K-CellStyle quota** in big reports | Reused immutable styles by design |
+| Casting between `HSSFWorkbook` / `XSSFWorkbook` for hex colours | Auto-detects format; hex falls back to nearest indexed on `.xls` |
+| `FileInputStream` / `FileOutputStream` lifecycle | Opened and closed internally |
+| `setCellValue` type dispatch | `setValue(Object)` — accepts `String`, `Number`, `Boolean`, `Date`, `LocalDate`, `null` |
+| 0-based POI indexes | 1-based public API (matches Excel UI) |
+| Bean-to-sheet and sheet-to-bean loops | `@ExcelColumn` + `writeBeans` / `readAsBeans` |
 
-```groovy
-dependencies {
-  implementation "solutions.bismi.excel:excel:1.1.12"
-}
-```
+### ⏱️ Time saved (measured in lines of code)
 
-### Gradle (Kotlin DSL)
-
-```kotlin
-dependencies {
-  implementation("solutions.bismi.excel:excel:1.1.12")
-}
-```
-
-### Scala
-
-```scala
-libraryDependencies += "solutions.bismi.excel" % "excel" % "1.1.12"
-```
+| Task | Apache POI | **Excel** | Ratio |
+|---|---:|---:|---:|
+| Create `.xlsx` + write "Hello World" with a style | ~15 | **5** | **3×** |
+| Write `List<Bean>` as a styled, filtered, frozen table | ~60 | **5** | **12×** |
+| Apply one reused style to 1,000 cells | ~8 / cell (repeat loops) | **1** | ≫10× |
+| Read sheet into `List<Map<String,String>>` | ~30 | **1** | **30×** |
+| Round-trip `List<Bean>` → file → `List<Bean>` | ~80 | **2** | **40×** |
+| Freeze header + auto-filter + column widths | ~20 | **3** | **7×** |
 
 ---
 
-## 📑 Index
+## 🚀 Jump-away examples
 
-- [Why *Excel*?](#🚀--why-excel)
-- [Features ☑️](#features-☑️)
-- [Quick Start](#quick-start-)
-- [Usage Snippets](#usage-snippets)
-  - [Workbook Basics](#workbook-basics)
-  - [Cell Goodies](#cell-goodies)
-  - [Rows & Columns](#rows--columns)
-  - [Merging Cells](#merging-cells)
-- [Advanced Demo 🛠️](#advanced-demo-)
-- [Architecture](#architecture)
-- [Comparison 🆚 POI / JExcel](#comparison--🆚-poi--jexcel)
-- [Contributing 🤝](#contributing-)
-- [License](#license)
-
----
-
-## Features ☑️
-
-|                      |                                                                     |
-| -------------------- | ------------------------------------------------------------------- |
-| 📑 **Workbook**      | create, open, save, multi‑format (.xlsx / .xls)                     |
-| 📄 **Sheets**        | add / rename / activate / protect                                   |
-| 📝 **Cells**         | text, numbers, dates, formulas, conditional formatting              |
-| 🎨 **Styling**       | fonts, colours (named ✨ or hex), borders, alignment, number formats |
-| 📋 **Rows/Cols**     | bulk value setting, auto‑fit, insert/delete                         |
-| 🔗 **Merge/Unmerge** | succinct helpers & intersection safety checks                       |
-
-Fast: streams large datasets (100 k+ rows) & reuses POI styles to keep memory low.
-
----
-
-## Quick Start 🎉
+### 1 · Hello, styled workbook (6 lines)
 
 ```java
 ExcelApplication app = new ExcelApplication();
 ExcelWorkBook wb = app.createWorkBook("demo.xlsx");
 ExcelWorkSheet sh = wb.addSheet("Summary");
-sh.activate();
-sh.cell(1,1).setText("Hello World");
-sh.cell(1,1).setFontStyle(true, false, false);
-sh.cell(1,1).setFillColor("LIGHT_GREEN");
+sh.cell(1,1).setText("Hello World").applyStyle(ExcelStyle.header());
 wb.saveWorkbook();
 app.closeAllWorkBooks();
 ```
 
-Runs on Java 17+; produces a styled workbook in seconds.
-
----
-
-## Usage Snippets
-
-### Workbook Basics
+### 2 · Bean → styled report (one call)
 
 ```java
-ExcelApplication app = new ExcelApplication();
-ExcelWorkBook wb = app.openWorkbook("existing.xls");
-wb.addSheet("2025-Q2");
-System.out.println(wb.getSheetCount());
+public class Product {
+    @ExcelColumn(name = "SKU",   order = 1)                      String sku;
+    @ExcelColumn(name = "Item",  order = 2)                      String name;
+    @ExcelColumn(name = "Units", order = 3, format = "#,##0")    int    units;
+    @ExcelColumn(name = "Price", order = 4, format = "$#,##0.00") double price;
+}
+
+ReportBuilder.on(sheet)
+    .title("Catalog")
+    .rowsFromBeans(productList)
+    .zebraStripes(true).freezeHeader(true).autoFilter(true)
+    .render();
 ```
 
-### Cell Goodies
+### 3 · `List<Map>` → spreadsheet
 
 ```java
-ExcelCell c = wb.getActiveSheet().cell(2,3);
-c.setNumericValue(42);
-c.setNumberFormat("#,##0.00");
-c.setFontColor("#FF9900");
-c.setHorizontalAlignment("RIGHT");
+List<Map<String,Object>> rows = List.of(
+    Map.of("Item","Apple", "Qty",10, "Price",1.20),
+    Map.of("Item","Pear",  "Qty", 8, "Price",1.80));
+
+sheet.writeMaps(rows).freezePane(2,1).autoSizeAllColumns();
 ```
 
-### Rows & Columns
+### 4 · Read Excel → `List<Bean>`
 
 ```java
-String[] header = {"Item","Qty","Price","Total"};
-ExcelRow row = wb.getActiveSheet().row(5);
-row.setRowValues(header);
-row.setFontColor("white");
-row.setFillColor("grey_50_percent");
-row.setFullBorder("black");
+List<Product> products = sheet.readAsBeans(Product.class);   // headers → fields
 ```
 
-### Merging Cells
+### 5 · Reusable style, applied 1,000 times
 
 ```java
-ExcelWorkSheet s = wb.getActiveSheet();
-s.mergeCells(1,1,1,5);                 // A1:E1
+ExcelStyle money = ExcelStyle.builder()
+        .numberFormat("$#,##0.00").horizontalAlignment("RIGHT").fullBorder("black").build();
 
-// later…
-if (s.isCellMerged(1,3)) s.unmergeCells(1,1,1,5);
+for (int r = 2; r <= 1001; r++) {
+    sheet.cell(r, 3).setValue(revenue[r-2]).applyStyle(money);   // one style, many cells
+}
+```
+
+### 6 · Hyperlinks & comments
+
+```java
+sheet.cell(1,1).setHyperlink("https://bismi.solutions", "Bismi Solutions");
+sheet.cell(1,1).setComment("Official site", "Release notes");
 ```
 
 ---
 
-## Advanced Demo 🛠️
+## 🖼️ Runnable examples (each image is produced by the linked file)
 
-*See **`examples/SalesReport.java`** — multi‑sheet, fully‑formatted workbook with charts in under 80 LOC.*
+Every example below is a real file under [`examples/`](examples) that you can run with
+`mvn compile exec:java -Dexec.mainClass=<className>`. Each screenshot is a faithful
+mock of the workbook it produces — colours, zebra, freeze pane, auto-filter, and all.
+
+### 📦 Invoice — merged title · address blocks · line items · formulas · totals
+
+<p align="center">
+  <img src="docs/invoice-preview.svg" alt="Invoice produced by InvoiceExample.java" width="90%"/>
+</p>
+
+> Source: [`examples/InvoiceExample.java`](examples/InvoiceExample.java) ·
+> Showcases: cell merging · reusable label/address/currency styles · formulas (`A*C`, `SUM`, tax) · bordered totals row · column widths.
 
 ---
 
-## Architecture
+### 📊 Executive Dashboard — KPI tiles · chart-ready sheet · raw data
 
+<p align="center">
+  <img src="docs/dashboard-preview.svg" alt="Dashboard produced by DashboardExample.java" width="95%"/>
+</p>
+
+> Source: [`examples/DashboardExample.java`](examples/DashboardExample.java) ·
+> Showcases: 4 colour-coded KPI tiles (green/blue/orange/red) built from merged cells ·
+> second sheet with `ReportBuilder` top-products table · third sheet with mixed-type raw data · frozen header + auto-filter.
+
+---
+
+### 👥 Employee Directory — beans + hyperlinks + comments + round-trip read
+
+<p align="center">
+  <img src="docs/employee-preview.svg" alt="Directory produced by EmployeeDirectoryExample.java" width="98%"/>
+</p>
+
+> Source: [`examples/EmployeeDirectoryExample.java`](examples/EmployeeDirectoryExample.java) ·
+> Showcases: `@ExcelColumn` beans · zebra stripes · frozen header · auto-filter ·
+> `mailto:` hyperlinks on the email column · greyed-italic style for inactive rows ·
+> cell comment with author · **round-trip read back into `List<Employee>` via `readAsBeans`**.
+
+---
+
+### 🗂️ Three-in-one Collection Report — beans, maps, raw
+
+> Source: [`examples/CollectionReportExample.java`](examples/CollectionReportExample.java) ·
+> Sheet 1 uses `ReportBuilder.rowsFromBeans(List<Product>)`, sheet 2 uses `rowsFromMaps(List<Map>)`
+> with a currency override on column 3, sheet 3 uses the bare-minimum `sheet.writeMaps(...)`.
+
+---
+
+## 📦 Installation
+
+### Maven
+```xml
+<dependency>
+  <groupId>solutions.bismi.excel</groupId>
+  <artifactId>excel</artifactId>
+  <version>1.2.0</version>
+</dependency>
 ```
-ExcelApplication
- └─ ExcelWorkBook
-     └─ ExcelWorkSheet
-         ├─ ExcelRow
-         └─ ExcelCell
+
+### Gradle (Kotlin DSL)
+```kotlin
+implementation("solutions.bismi.excel:excel:1.2.0")
 ```
 
-Each object only exposes context‑appropriate methods, making code completion your best documentation.
+### Gradle (Groovy DSL)
+```groovy
+implementation "solutions.bismi.excel:excel:1.2.0"
+```
+
+**Requires:** Java 17+  ·  Works on Windows · macOS · Linux.
 
 ---
 
-## Comparison 🆚 POI / JExcel
+## ☑️ Features at a glance
 
-|  Capability              |  Excel (lib) | Apache POI | JExcel API    |
-| ------------------------- | ------------ | ---------- | ------------- |
-| Fluent API                | ⭐⭐⭐⭐⭐        | ⭐⭐         | ⭐⭐⭐           |
-| Large‑data memory profile | ⭐⭐⭐⭐         | ⭐⭐⭐        | ⭐⭐⭐⭐          |
-| XLSX support              | ✅            | ✅          | ⚠ (read‑only) |
-| Styling shorthand         | Yes          | No         | Limited       |
-| Active development        | ✅            | ✅          | ❌             |
+| Area | What's in the box |
+|---|---|
+| 📑 **Workbook** | create · open · save · `.xlsx` + `.xls` |
+| 📄 **Sheets** | add · rename · activate · freeze panes · auto-filter · protect (password) |
+| 📝 **Cells** | text · numbers · dates · formulas · **polymorphic `setValue(Object)`** · hyperlinks · comments |
+| 🎨 **Styling** | fonts · 52 named colours ✨ · hex colours (XLSX) · borders · alignment · number formats · **reusable `ExcelStyle`** + presets |
+| 📋 **Rows/Cols** | bulk values (mixed types) · auto-fit · column width · range styling |
+| 🔗 **Merge/Unmerge** | succinct helpers · overlap safety checks |
+| 🗂️ **Collections** | `writeMaps` · `writeBeans` · `readAsMaps` · `readAsBeans` · `@ExcelColumn` annotation |
+| 🏗️ **Reports** | `ReportBuilder` — title · headers · zebra · freeze · auto-filter · per-column formats · column widths |
+| 🧪 **Quality** | 91 unit tests (incl. every README snippet) · CI · Codecov · Sonar · Snyk |
 
 ---
 
-## Contributing 🤝
+## 🗺️ Architecture
+
+```mermaid
+graph TD
+    A[ExcelApplication<br/><i>lifecycle & open workbooks</i>] --> B[ExcelWorkBook<br/><i>file I/O, sheets</i>]
+    B --> C[ExcelWorkSheet<br/><i>data, layout, filters</i>]
+    C --> D[ExcelRow<br/><i>bulk values & styling</i>]
+    C --> E[ExcelCell<br/><i>values, style, hyperlink, comment</i>]
+    C -.uses.-> F[ReportBuilder<br/><i>one-call styled tables</i>]
+    D -.applies.-> G[ExcelStyle<br/><i>reusable style defs</i>]
+    E -.applies.-> G
+    C -.reads/writes.-> H[List&lt;Map&gt; · List&lt;Bean&gt;<br/><i>@ExcelColumn</i>]
+
+    style A fill:#2d6cdf,color:#fff,stroke:#1e4fb2
+    style B fill:#2d9fdf,color:#fff,stroke:#1e7ba2
+    style C fill:#36b37e,color:#fff,stroke:#278658
+    style F fill:#ff9f43,color:#fff,stroke:#c77c2e
+    style G fill:#9b59b6,color:#fff,stroke:#6d3a87
+    style H fill:#e74c3c,color:#fff,stroke:#a33325
+```
+
+Each class exposes only methods appropriate to its scope — code completion *is* your documentation.
+
+### Data-flow for a collection-driven report
+
+```mermaid
+flowchart LR
+    subgraph Your_Data
+      M["List&lt;Map&lt;String,Object&gt;&gt;"]
+      B["List&lt;Bean&gt;<br/>@ExcelColumn"]
+      A["Object[] rows"]
+    end
+    subgraph Excel_Lib
+      RB[ReportBuilder]
+      WS[ExcelWorkSheet]
+      ST[ExcelStyle]
+    end
+    Out[(workbook.xlsx)]
+
+    M --> RB
+    B --> RB
+    A --> RB
+    M --> WS
+    B --> WS
+    RB -->|title · headers · data · zebra · freeze · filter| WS
+    ST -.applies.-> WS
+    WS --> Out
+
+    style M fill:#fdf6e3,stroke:#b58900
+    style B fill:#fdf6e3,stroke:#b58900
+    style A fill:#fdf6e3,stroke:#b58900
+    style RB fill:#ff9f43,color:#fff,stroke:#c77c2e
+    style WS fill:#36b37e,color:#fff,stroke:#278658
+    style ST fill:#9b59b6,color:#fff,stroke:#6d3a87
+    style Out fill:#2d6cdf,color:#fff,stroke:#1e4fb2
+```
+
+---
+
+## 🧱 Style reuse at a glance
+
+```java
+ExcelStyle header = ExcelStyle.header();         // grey fill · white bold · centred · bordered
+ExcelStyle zebra  = ExcelStyle.zebraStripe();    // light-grey fill
+ExcelStyle money  = ExcelStyle.currency();       // right-aligned $#,##0.00
+ExcelStyle pct    = ExcelStyle.percent();        // right-aligned 0.00%
+ExcelStyle when   = ExcelStyle.date();           // dd-MMM-yyyy
+
+ExcelStyle custom = ExcelStyle.builder()
+        .fontColor("white").fillColor("#0d4ba1")
+        .bold(true).horizontalAlignment("CENTER").fullBorder("black")
+        .build();
+```
+
+Apply to anything:
+
+```java
+sheet.row(1).applyStyle(header);
+sheet.row(5).applyStyle(money, 2, 6);            // cells 2..5 of row 5
+sheet.cell(10,3).applyStyle(money);              // single cell
+```
+
+---
+
+## 🤝 Contributing
 
 ```bash
 git clone https://github.com/Bismi-Solutions/Excel.git
 cd Excel
-mvn test   # green? great – pick an issue and hack away!
+mvn test        # 91 tests — all green is the baseline
 ```
 
-Pull requests are welcome. Please include unit tests and follow the log‑level convention:
+PRs welcome. Please include unit tests and follow the log-level convention:
 
-- **info** → user‑visible events (file created, sheet saved)
+- **info** → user-visible events (file created, sheet saved)
 - **debug** → flow diagnostics
 - **warn/error** → exceptional situations
 
+Area ideas that need love: charts · conditional formatting · data validation (dropdowns) · named ranges · images · pivot tables.
+
 ---
 
-## License
+## 📄 License
 
-MIT – *use it, fork it, profit.*  See [LICENSE](LICENSE).
+MIT — *use it, fork it, profit.* See [LICENSE](LICENSE).

--- a/docs/dashboard-preview.svg
+++ b/docs/dashboard-preview.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 560" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="900" height="540" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="900" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="900" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">dashboard.xlsx — Summary</text>
+
+  <!-- Title (merged A1:H1) -->
+  <rect x="30" y="58" width="860" height="40" fill="#0d4ba1"/>
+  <text x="460" y="84" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">Q3 Executive Dashboard</text>
+
+  <!-- KPI tiles -->
+  <!-- Tile 1 Revenue (green) -->
+  <rect x="40"  y="120" width="200" height="30" fill="#1a7f37"/>
+  <text x="140" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">REVENUE</text>
+  <rect x="40"  y="150" width="200" height="62" fill="#d9d9d9" stroke="#24292f" stroke-width="1.5"/>
+  <text x="140" y="190" font-size="22" fill="#24292f" font-weight="700" text-anchor="middle">$1,248,500</text>
+
+  <!-- Tile 2 Orders (blue) -->
+  <rect x="255" y="120" width="200" height="30" fill="#2d6cdf"/>
+  <text x="355" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">ORDERS</text>
+  <rect x="255" y="150" width="200" height="62" fill="#d9d9d9" stroke="#24292f" stroke-width="1.5"/>
+  <text x="355" y="190" font-size="22" fill="#24292f" font-weight="700" text-anchor="middle">4,812</text>
+
+  <!-- Tile 3 New Customers (orange) -->
+  <rect x="470" y="120" width="200" height="30" fill="#bc4c00"/>
+  <text x="570" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">NEW CUSTOMERS</text>
+  <rect x="470" y="150" width="200" height="62" fill="#d9d9d9" stroke="#24292f" stroke-width="1.5"/>
+  <text x="570" y="190" font-size="22" fill="#24292f" font-weight="700" text-anchor="middle">1,203</text>
+
+  <!-- Tile 4 Return Rate (red) -->
+  <rect x="685" y="120" width="200" height="30" fill="#cf222e"/>
+  <text x="785" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">RETURN RATE</text>
+  <rect x="685" y="150" width="200" height="62" fill="#d9d9d9" stroke="#24292f" stroke-width="1.5"/>
+  <text x="785" y="190" font-size="22" fill="#24292f" font-weight="700" text-anchor="middle">2.4%</text>
+
+  <!-- Highlights -->
+  <text x="40" y="248" font-size="13" fill="#24292f" font-weight="700">Highlights</text>
+  <text x="40" y="268" font-size="12" fill="#24292f">• Widget Pro led revenue at $18,375</text>
+  <text x="40" y="286" font-size="12" fill="#24292f">• North region grew 12.4% QoQ</text>
+  <text x="40" y="304" font-size="12" fill="#24292f">• Legacy Kit flagged for review</text>
+
+  <!-- Simple bar chart (simulated) -->
+  <g>
+    <text x="500" y="248" font-size="13" fill="#24292f" font-weight="700">Revenue by Product</text>
+    <rect x="500" y="260" width="160" height="18" fill="#2d6cdf"/>
+    <rect x="500" y="282" width="220" height="18" fill="#2d6cdf"/>
+    <rect x="500" y="304" width="78" height="18" fill="#2d6cdf"/>
+    <rect x="500" y="326" width="55" height="18" fill="#2d6cdf"/>
+    <rect x="500" y="348" width="270" height="18" fill="#2d6cdf"/>
+    <text x="495" y="273" font-size="11" fill="#57606a" text-anchor="end">Widget Pro</text>
+    <text x="495" y="295" font-size="11" fill="#57606a" text-anchor="end">Gadget Max</text>
+    <text x="495" y="317" font-size="11" fill="#57606a" text-anchor="end">Contraption</text>
+    <text x="495" y="339" font-size="11" fill="#57606a" text-anchor="end">Gizmo Lite</text>
+    <text x="495" y="361" font-size="11" fill="#57606a" text-anchor="end">Flagship X</text>
+    <text x="670" y="273" font-size="10" fill="#24292f">$18.4k</text>
+    <text x="730" y="295" font-size="10" fill="#24292f">$24.9k</text>
+    <text x="588" y="317" font-size="10" fill="#24292f">$9.5k</text>
+    <text x="565" y="339" font-size="10" fill="#24292f">$6.2k</text>
+    <text x="780" y="361" font-size="10" fill="#24292f">$31.2k</text>
+  </g>
+
+  <!-- Sheet tabs -->
+  <rect x="10" y="510" width="900" height="30" fill="#f6f8fa" stroke="#d0d7de"/>
+  <rect x="20" y="512" width="100" height="28" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="70" y="530" font-size="12" fill="#0d4ba1" font-weight="700" text-anchor="middle">Summary</text>
+  <rect x="120" y="512" width="110" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="175" y="530" font-size="12" fill="#24292f" text-anchor="middle">TopProducts</text>
+  <rect x="230" y="512" width="100" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="280" y="530" font-size="12" fill="#24292f" text-anchor="middle">RawData</text>
+
+  <!-- Code callout -->
+  <rect x="40" y="390" width="840" height="100" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="410" font-size="12" fill="#24292f" font-weight="700">examples/DashboardExample.java</text>
+  <text x="56" y="430" font-size="11" fill="#57606a" font-family="Consolas, monospace">kpiTile(sh, 3, 1, "REVENUE", "$1,248,500", "#1a7f37");</text>
+  <text x="56" y="446" font-size="11" fill="#57606a" font-family="Consolas, monospace">ReportBuilder.on(topProductsSheet)</text>
+  <text x="56" y="462" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .title("Top Products by Revenue").rowsFromBeans(data)</text>
+  <text x="56" y="478" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .zebraStripes(true).freezeHeader(true).autoFilter(true).render();</text>
+</svg>

--- a/docs/employee-preview.svg
+++ b/docs/employee-preview.svg
@@ -168,9 +168,9 @@
     <rect x="780" y="224" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
     <rect x="890" y="224" width="80"  height="28" fill="#ffffff" stroke="#d0d7de"/>
     <text x="70"  y="242" text-anchor="middle">105</text>
-    <text x="112" y="242">Priya Naidu</text>
+    <text x="112" y="242">John Jones</text>
     <text x="272" y="242">Designer</text>
-    <text x="452" y="242" fill="#0969da" text-decoration="underline">priya.naidu@example.com</text>
+    <text x="452" y="242" fill="#0969da" text-decoration="underline">john.jones@example.com</text>
     <text x="720" y="242" text-anchor="middle">15-Jun-2023</text>
     <text x="880" y="242" text-anchor="end">$88,000</text>
     <text x="930" y="242" text-anchor="middle">true</text>

--- a/docs/employee-preview.svg
+++ b/docs/employee-preview.svg
@@ -1,0 +1,197 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 500" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <linearGradient id="hdr" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2d6cdf"/>
+      <stop offset="100%" stop-color="#1e4fb2"/>
+    </linearGradient>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="960" height="480" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="960" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="960" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">employees.xlsx — Directory</text>
+
+  <!-- Column letter row -->
+  <g font-size="11" fill="#57606a" text-anchor="middle">
+    <rect x="10"  y="58" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="40"  y="58" width="60"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="100" y="58" width="160" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="260" y="58" width="180" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="440" y="58" width="220" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="660" y="58" width="120" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="780" y="58" width="110" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="890" y="58" width="80"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="73">#</text>
+    <text x="70"  y="73">A</text>
+    <text x="180" y="73">B</text>
+    <text x="350" y="73">C</text>
+    <text x="550" y="73">D</text>
+    <text x="720" y="73">E</text>
+    <text x="835" y="73">F</text>
+    <text x="930" y="73">G</text>
+  </g>
+
+  <!-- Header row (row 1 in file — no title) -->
+  <rect x="10" y="80" width="30" height="32" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="100" font-size="11" fill="#57606a" text-anchor="middle">1</text>
+  <g font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">
+    <rect x="40"  y="80" width="60"  height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="100" y="80" width="160" height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="260" y="80" width="180" height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="440" y="80" width="220" height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="660" y="80" width="120" height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="780" y="80" width="110" height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <rect x="890" y="80" width="80"  height="32" fill="url(#hdr)" stroke="#0d4ba1"/>
+    <text x="70"  y="100">Id</text>
+    <text x="180" y="100">Name</text>
+    <text x="350" y="100">Role</text>
+    <text x="550" y="100">Email</text>
+    <text x="720" y="100">Joined</text>
+    <text x="835" y="100">Salary</text>
+    <text x="930" y="100">Active</text>
+  </g>
+  <!-- auto-filter triangles -->
+  <g fill="#ffffff">
+    <polygon points="88,95 96,95 92,101"/>
+    <polygon points="248,95 256,95 252,101"/>
+    <polygon points="428,95 436,95 432,101"/>
+    <polygon points="648,95 656,95 652,101"/>
+    <polygon points="768,95 776,95 772,101"/>
+    <polygon points="878,95 886,95 882,101"/>
+    <polygon points="958,95 966,95 962,101"/>
+  </g>
+
+  <!-- Freeze marker -->
+  <line x1="40" y1="112" x2="970" y2="112" stroke="#2d6cdf" stroke-width="0.8" stroke-dasharray="4,2" opacity="0.6"/>
+  <text x="960" y="108" font-size="9" fill="#2d6cdf" text-anchor="end" font-weight="700">↑ header frozen</text>
+
+  <!-- Data rows -->
+  <!-- Row 2 (white) — with red comment triangle on Name -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="112" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="130" font-size="11" fill="#57606a" text-anchor="middle">2</text>
+    <rect x="40"  y="112" width="60"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="100" y="112" width="160" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="260" y="112" width="180" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="440" y="112" width="220" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="660" y="112" width="120" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="780" y="112" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="890" y="112" width="80"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="70"  y="130" text-anchor="middle">101</text>
+    <text x="112" y="130">Amina Khan</text>
+    <text x="272" y="130">Engineer</text>
+    <text x="452" y="130" fill="#0969da" text-decoration="underline">amina.khan@example.com</text>
+    <text x="720" y="130" text-anchor="middle">12-Jul-2021</text>
+    <text x="880" y="130" text-anchor="end">$95,000</text>
+    <text x="930" y="130" text-anchor="middle">true</text>
+  </g>
+  <!-- comment indicator on Name cell -->
+  <polygon points="255,113 260,113 260,118" fill="#cf222e"/>
+
+  <!-- Row 3 (zebra) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="140" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="158" font-size="11" fill="#57606a" text-anchor="middle">3</text>
+    <rect x="40"  y="140" width="60"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="100" y="140" width="160" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="260" y="140" width="180" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="440" y="140" width="220" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="660" y="140" width="120" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="780" y="140" width="110" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="890" y="140" width="80"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="70"  y="158" text-anchor="middle">102</text>
+    <text x="112" y="158">Rahul Menon</text>
+    <text x="272" y="158">Senior Engineer</text>
+    <text x="452" y="158" fill="#0969da" text-decoration="underline">rahul.menon@example.com</text>
+    <text x="720" y="158" text-anchor="middle">04-Mar-2019</text>
+    <text x="880" y="158" text-anchor="end">$135,000</text>
+    <text x="930" y="158" text-anchor="middle">true</text>
+  </g>
+
+  <!-- Row 4 (white) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="168" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="186" font-size="11" fill="#57606a" text-anchor="middle">4</text>
+    <rect x="40"  y="168" width="60"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="100" y="168" width="160" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="260" y="168" width="180" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="440" y="168" width="220" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="660" y="168" width="120" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="780" y="168" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="890" y="168" width="80"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="70"  y="186" text-anchor="middle">103</text>
+    <text x="112" y="186">Sofia Gomez</text>
+    <text x="272" y="186">Product Manager</text>
+    <text x="452" y="186" fill="#0969da" text-decoration="underline">sofia.gomez@example.com</text>
+    <text x="720" y="186" text-anchor="middle">21-Nov-2022</text>
+    <text x="880" y="186" text-anchor="end">$110,000</text>
+    <text x="930" y="186" text-anchor="middle">true</text>
+  </g>
+
+  <!-- Row 5 (zebra + INACTIVE grey italic) -->
+  <g font-size="12" fill="#6e7781" font-style="italic">
+    <rect x="10"  y="196" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="214" font-size="11" fill="#57606a" text-anchor="middle" font-style="normal">5</text>
+    <rect x="40"  y="196" width="60"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="100" y="196" width="160" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="260" y="196" width="180" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="440" y="196" width="220" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="660" y="196" width="120" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="780" y="196" width="110" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="890" y="196" width="80"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="70"  y="214" text-anchor="middle">104</text>
+    <text x="112" y="214">Dmitri Ivanov</text>
+    <text x="272" y="214">QA Lead</text>
+    <text x="452" y="214" fill="#6e7781" text-decoration="underline">dmitri.ivanov@example.com</text>
+    <text x="720" y="214" text-anchor="middle">09-Jan-2018</text>
+    <text x="880" y="214" text-anchor="end">$120,000</text>
+    <text x="930" y="214" text-anchor="middle">false</text>
+  </g>
+
+  <!-- Row 6 (white) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="224" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="242" font-size="11" fill="#57606a" text-anchor="middle">6</text>
+    <rect x="40"  y="224" width="60"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="100" y="224" width="160" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="260" y="224" width="180" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="440" y="224" width="220" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="660" y="224" width="120" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="780" y="224" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="890" y="224" width="80"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="70"  y="242" text-anchor="middle">105</text>
+    <text x="112" y="242">Priya Naidu</text>
+    <text x="272" y="242">Designer</text>
+    <text x="452" y="242" fill="#0969da" text-decoration="underline">priya.naidu@example.com</text>
+    <text x="720" y="242" text-anchor="middle">15-Jun-2023</text>
+    <text x="880" y="242" text-anchor="end">$88,000</text>
+    <text x="930" y="242" text-anchor="middle">true</text>
+  </g>
+
+  <!-- Comment popup (next to row 2 Name cell) -->
+  <g filter="url(#shadow)">
+    <rect x="280" y="145" width="240" height="54" rx="4" fill="#fffbd7" stroke="#bf8700"/>
+    <text x="292" y="164" font-size="11" fill="#57606a" font-weight="700">HR Team:</text>
+    <text x="292" y="180" font-size="11" fill="#24292f">Go-to for onboarding questions</text>
+  </g>
+  <line x1="260" y1="125" x2="280" y2="155" stroke="#bf8700" stroke-width="1" stroke-dasharray="2,2"/>
+
+  <!-- Code callout -->
+  <rect x="40" y="290" width="900" height="160" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="310" font-size="12" fill="#24292f" font-weight="700">examples/EmployeeDirectoryExample.java — Write + round-trip read</text>
+  <text x="56" y="334" font-size="11" fill="#57606a" font-family="Consolas, monospace">ReportBuilder.on(sheet).rowsFromBeans(staff)</text>
+  <text x="56" y="350" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .zebraStripes(true).freezeHeader(true).autoFilter(true).render();</text>
+  <text x="56" y="372" font-size="11" fill="#57606a" font-family="Consolas, monospace">// post-process: hyperlink emails + pin a comment</text>
+  <text x="56" y="388" font-size="11" fill="#57606a" font-family="Consolas, monospace">sheet.cell(row, 4).setHyperlink("mailto:" + emp.email, emp.email);</text>
+  <text x="56" y="404" font-size="11" fill="#57606a" font-family="Consolas, monospace">sheet.cell(2, 2).setComment("Go-to for onboarding questions", "HR Team");</text>
+  <text x="56" y="426" font-size="11" fill="#57606a" font-family="Consolas, monospace">// read the same file back into a List&lt;Employee&gt;</text>
+  <text x="56" y="442" font-size="11" fill="#57606a" font-family="Consolas, monospace">List&lt;Employee&gt; staff = sheet.readAsBeans(Employee.class);</text>
+</svg>

--- a/docs/invoice-preview.svg
+++ b/docs/invoice-preview.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 620" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="800" height="600" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="800" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="800" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">invoice.xlsx — Excel</text>
+
+  <!-- Title row (merged A1:E1) -->
+  <rect x="30" y="60" width="760" height="42" fill="#0d4ba1"/>
+  <text x="410" y="87" font-size="22" font-weight="700" fill="#ffffff" text-anchor="middle">INVOICE</text>
+
+  <!-- Invoice meta -->
+  <text x="40"  y="130" font-size="12" fill="#0d4ba1" font-weight="700">Invoice #:</text>
+  <text x="130" y="130" font-size="12" fill="#24292f">INV-2026-0042</text>
+  <text x="480" y="130" font-size="12" fill="#0d4ba1" font-weight="700">Date:</text>
+  <text x="540" y="130" font-size="12" fill="#24292f">21-Apr-2026</text>
+
+  <!-- From / Bill To labels -->
+  <text x="40"  y="170" font-size="12" fill="#0d4ba1" font-weight="700">From</text>
+  <text x="480" y="170" font-size="12" fill="#0d4ba1" font-weight="700">Bill To</text>
+
+  <!-- From block (grey fill) -->
+  <rect x="40"  y="178" width="400" height="62" fill="#ebeef2" stroke="#d0d7de"/>
+  <text x="52" y="198" font-size="12" fill="#24292f">Bismi Solutions</text>
+  <text x="52" y="215" font-size="12" fill="#24292f">Tech Park, Level 4</text>
+  <text x="52" y="232" font-size="12" fill="#24292f">Chennai, India 600001</text>
+
+  <!-- Bill To block -->
+  <rect x="480" y="178" width="300" height="62" fill="#ebeef2" stroke="#d0d7de"/>
+  <text x="492" y="198" font-size="12" fill="#24292f">Acme Corp.</text>
+  <text x="492" y="215" font-size="12" fill="#24292f">123 Market Street</text>
+  <text x="492" y="232" font-size="12" fill="#24292f">New York, NY 10001</text>
+
+  <!-- Line items table header -->
+  <rect x="40"  y="270" width="60"  height="30" fill="#636363" stroke="#404040"/>
+  <rect x="100" y="270" width="400" height="30" fill="#636363" stroke="#404040"/>
+  <rect x="500" y="270" width="140" height="30" fill="#636363" stroke="#404040"/>
+  <rect x="640" y="270" width="140" height="30" fill="#636363" stroke="#404040"/>
+  <g font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">
+    <text x="70"  y="289">Qty</text>
+    <text x="300" y="289">Description</text>
+    <text x="570" y="289">Unit Price</text>
+    <text x="710" y="289">Total</text>
+  </g>
+
+  <!-- Line items -->
+  <g font-size="12" fill="#24292f">
+    <!-- Row 1 -->
+    <rect x="40"  y="300" width="60"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="100" y="300" width="400" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="500" y="300" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="640" y="300" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="70"  y="319" text-anchor="middle">5</text>
+    <text x="114" y="319">Excel library — enterprise licence</text>
+    <text x="630" y="319" text-anchor="end">$299.00</text>
+    <text x="770" y="319" text-anchor="end">$1,495.00</text>
+
+    <!-- Row 2 -->
+    <rect x="40"  y="328" width="60"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="100" y="328" width="400" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="500" y="328" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="640" y="328" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="70"  y="347" text-anchor="middle">12</text>
+    <text x="114" y="347">Premium support — hours</text>
+    <text x="630" y="347" text-anchor="end">$150.00</text>
+    <text x="770" y="347" text-anchor="end">$1,800.00</text>
+
+    <!-- Row 3 -->
+    <rect x="40"  y="356" width="60"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="100" y="356" width="400" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="500" y="356" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="640" y="356" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="70"  y="375" text-anchor="middle">1</text>
+    <text x="114" y="375">Onsite training day</text>
+    <text x="630" y="375" text-anchor="end">$1,200.00</text>
+    <text x="770" y="375" text-anchor="end">$1,200.00</text>
+
+    <!-- Row 4 -->
+    <rect x="40"  y="384" width="60"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="100" y="384" width="400" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="500" y="384" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="640" y="384" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="70"  y="403" text-anchor="middle">3</text>
+    <text x="114" y="403">Custom reporting setup</text>
+    <text x="630" y="403" text-anchor="end">$450.00</text>
+    <text x="770" y="403" text-anchor="end">$1,350.00</text>
+  </g>
+
+  <!-- Totals -->
+  <rect x="500" y="440" width="140" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <rect x="640" y="440" width="140" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="512" y="458" font-size="12" fill="#0d4ba1" font-weight="700">Subtotal</text>
+  <text x="770" y="458" font-size="12" fill="#24292f" text-anchor="end">$5,845.00</text>
+
+  <rect x="500" y="466" width="140" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <rect x="640" y="466" width="140" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="512" y="484" font-size="12" fill="#0d4ba1" font-weight="700">Tax (8%)</text>
+  <text x="770" y="484" font-size="12" fill="#24292f" text-anchor="end">$467.60</text>
+
+  <rect x="500" y="492" width="140" height="34" fill="#e6eefc" stroke="#2d6cdf" stroke-width="1.5"/>
+  <rect x="640" y="492" width="140" height="34" fill="#e6eefc" stroke="#2d6cdf" stroke-width="1.5"/>
+  <text x="512" y="514" font-size="13" fill="#0d4ba1" font-weight="700">TOTAL</text>
+  <text x="770" y="514" font-size="13" fill="#0d4ba1" font-weight="700" text-anchor="end">$6,312.60</text>
+
+  <!-- Code callout -->
+  <rect x="40" y="545" width="740" height="55" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="565" font-size="11" fill="#24292f" font-weight="700">examples/InvoiceExample.java</text>
+  <text x="56" y="582" font-size="10.5" fill="#57606a" font-family="Consolas, monospace">sh.cell(r, 4).setFormula("A" + r + "*C" + r).applyStyle(money);</text>
+  <text x="56" y="595" font-size="10.5" fill="#57606a" font-family="Consolas, monospace">sh.cell(totalsRow, 4).setFormula("SUM(D" + startRow + ":D" + (totalsRow-2) + ")").applyStyle(money);</text>
+</svg>

--- a/docs/invoice-preview.svg
+++ b/docs/invoice-preview.svg
@@ -32,8 +32,8 @@
   <!-- From block (grey fill) -->
   <rect x="40"  y="178" width="400" height="62" fill="#ebeef2" stroke="#d0d7de"/>
   <text x="52" y="198" font-size="12" fill="#24292f">Bismi Solutions</text>
-  <text x="52" y="215" font-size="12" fill="#24292f">Tech Park, Level 4</text>
-  <text x="52" y="232" font-size="12" fill="#24292f">Chennai, India 600001</text>
+  <text x="52" y="215" font-size="12" fill="#24292f">Infopark, Phase II</text>
+  <text x="52" y="232" font-size="12" fill="#24292f">Kochi, India 682042</text>
 
   <!-- Bill To block -->
   <rect x="480" y="178" width="300" height="62" fill="#ebeef2" stroke="#d0d7de"/>

--- a/docs/kpi-preview.svg
+++ b/docs/kpi-preview.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 360" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="760" height="340" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="760" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="760" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">kpiTiles.xlsx — KPIs</text>
+
+  <!-- Title (merged A1:D1) with blue header style -->
+  <rect x="40" y="60" width="700" height="36" fill="#2d6cdf" stroke="#000"/>
+  <text x="390" y="84" font-size="16" font-weight="700" fill="#ffffff" text-anchor="middle">Q3 Snapshot</text>
+
+  <!-- KPI tile 1: Revenue (green) -->
+  <rect x="40"  y="120" width="170" height="30" fill="#1a7f37"/>
+  <text x="125" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">Revenue</text>
+  <rect x="40"  y="150" width="170" height="40" fill="#ffffff" stroke="#000" stroke-width="1.5"/>
+  <text x="125" y="178" font-size="18" fill="#24292f" font-weight="700" text-anchor="middle">$1,248,500</text>
+
+  <!-- KPI tile 2: Orders (blue) -->
+  <rect x="225" y="120" width="170" height="30" fill="#2d6cdf"/>
+  <text x="310" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">Orders</text>
+  <rect x="225" y="150" width="170" height="40" fill="#ffffff" stroke="#000" stroke-width="1.5"/>
+  <text x="310" y="178" font-size="18" fill="#24292f" font-weight="700" text-anchor="middle">4,812</text>
+
+  <!-- KPI tile 3: New Customers (orange) -->
+  <rect x="410" y="120" width="170" height="30" fill="#bc4c00"/>
+  <text x="495" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">New Customers</text>
+  <rect x="410" y="150" width="170" height="40" fill="#ffffff" stroke="#000" stroke-width="1.5"/>
+  <text x="495" y="178" font-size="18" fill="#24292f" font-weight="700" text-anchor="middle">1,203</text>
+
+  <!-- KPI tile 4: Return Rate (red) -->
+  <rect x="595" y="120" width="170" height="30" fill="#cf222e"/>
+  <text x="680" y="140" font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">Return Rate</text>
+  <rect x="595" y="150" width="170" height="40" fill="#ffffff" stroke="#000" stroke-width="1.5"/>
+  <text x="680" y="178" font-size="18" fill="#24292f" font-weight="700" text-anchor="middle">2.4%</text>
+
+  <!-- Code callout -->
+  <rect x="40" y="215" width="725" height="120" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="235" font-size="12" fill="#24292f" font-weight="700">examples/KpiTilesExample.java</text>
+  <text x="56" y="255" font-size="11" fill="#57606a" font-family="Consolas, monospace">kpi(sh, 1, "Revenue",       "$1,248,500", "#1a7f37");</text>
+  <text x="56" y="271" font-size="11" fill="#57606a" font-family="Consolas, monospace">kpi(sh, 2, "Orders",        "4,812",      "#2d6cdf");</text>
+  <text x="56" y="287" font-size="11" fill="#57606a" font-family="Consolas, monospace">kpi(sh, 3, "New Customers", "1,203",      "#bc4c00");</text>
+  <text x="56" y="303" font-size="11" fill="#57606a" font-family="Consolas, monospace">kpi(sh, 4, "Return Rate",   "2.4%",       "#cf222e");</text>
+  <text x="56" y="325" font-size="10.5" fill="#636363" font-style="italic">~15 lines of actual logic — no beans, no annotations, no loops</text>
+</svg>

--- a/docs/report-preview.svg
+++ b/docs/report-preview.svg
@@ -129,7 +129,7 @@
     <text x="420" y="226" text-anchor="end">$24,934.00</text>
     <text x="530" y="226" text-anchor="end" fill="#1a7f37" font-weight="600">▲ 8.75%</text>
     <text x="554" y="226">03-Feb-2026</text>
-    <text x="694" y="226">P. Naidu</text>
+    <text x="694" y="226">J. Smith</text>
   </g>
   <rect x="820" y="214" width="80" height="18" rx="9" fill="#d1f4dc" stroke="#1a7f37"/>
   <text x="860" y="227" font-size="11" fill="#1a7f37" font-weight="700" text-anchor="middle">Active</text>

--- a/docs/report-preview.svg
+++ b/docs/report-preview.svg
@@ -1,0 +1,261 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <linearGradient id="titleBar" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f6feb"/>
+      <stop offset="100%" stop-color="#0d4ba1"/>
+    </linearGradient>
+    <linearGradient id="headerBar" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2d6cdf"/>
+      <stop offset="100%" stop-color="#1e4fb2"/>
+    </linearGradient>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="900" height="500" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window title bar -->
+  <rect x="10" y="10" width="900" height="32" rx="6" fill="url(#titleBar)"/>
+  <rect x="10" y="30" width="900" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">Q3-Sales-Report.xlsx — Excel</text>
+
+  <!-- Ribbon-lite bar -->
+  <rect x="10" y="42" width="900" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="24" y="61" fill="#57606a" font-size="12">File  ·  Home  ·  Insert  ·  Page Layout  ·  Formulas  ·  Data  ·  Review  ·  View</text>
+
+  <!-- Name box + formula bar -->
+  <rect x="10" y="70" width="120" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="24" y="87" fill="#24292f" font-size="12" font-weight="600">A1</text>
+  <rect x="130" y="70" width="780" height="26" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="144" y="87" fill="#24292f" font-size="12">fx   Q3 Sales Report — Regional Breakdown</text>
+
+  <!-- Column letters -->
+  <g font-size="11" fill="#57606a" text-anchor="middle">
+    <rect x="10"  y="96" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="40"  y="96" width="170" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="210" y="96" width="90"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="300" y="96" width="130" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="430" y="96" width="110" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="540" y="96" width="140" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="680" y="96" width="130" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="810" y="96" width="100" height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="111">#</text>
+    <text x="125" y="111">A</text>
+    <text x="255" y="111">B</text>
+    <text x="365" y="111">C</text>
+    <text x="485" y="111">D</text>
+    <text x="610" y="111">E</text>
+    <text x="745" y="111">F</text>
+    <text x="860" y="111">G</text>
+  </g>
+
+  <!-- Row 1: Title (merged A1:G1) -->
+  <rect x="10"  y="118" width="30" height="32" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="138" font-size="11" fill="#57606a" text-anchor="middle">1</text>
+  <rect x="40" y="118" width="870" height="32" fill="#0f2d5c" stroke="#0a1f40"/>
+  <text x="475" y="138" font-size="15" fill="#ffffff" font-weight="700" text-anchor="middle">Q3 Sales Report — Regional Breakdown</text>
+
+  <!-- Row 2: Headers -->
+  <rect x="10" y="150" width="30" height="30" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="169" font-size="11" fill="#57606a" text-anchor="middle">2</text>
+
+  <g font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">
+    <rect x="40"  y="150" width="170" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="210" y="150" width="90"  height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="300" y="150" width="130" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="430" y="150" width="110" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="540" y="150" width="140" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="680" y="150" width="130" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <rect x="810" y="150" width="100" height="30" fill="url(#headerBar)" stroke="#0d4ba1"/>
+    <text x="125" y="169">Product</text>
+    <text x="255" y="169">Units</text>
+    <text x="365" y="169">Revenue</text>
+    <text x="485" y="169">Growth</text>
+    <text x="610" y="169">Launched</text>
+    <text x="745" y="169">Owner</text>
+    <text x="860" y="169">Status</text>
+  </g>
+  <!-- auto-filter dropdown arrows -->
+  <g fill="#ffffff">
+    <polygon points="198,164 206,164 202,170"/>
+    <polygon points="288,164 296,164 292,170"/>
+    <polygon points="418,164 426,164 422,170"/>
+    <polygon points="528,164 536,164 532,170"/>
+    <polygon points="668,164 676,164 672,170"/>
+    <polygon points="798,164 806,164 802,170"/>
+    <polygon points="898,164 906,164 902,170"/>
+  </g>
+
+  <!-- Data rows -->
+  <!-- Row 3 (white) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="180" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="198" font-size="11" fill="#57606a" text-anchor="middle">3</text>
+    <rect x="40"  y="180" width="170" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="210" y="180" width="90"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="180" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="430" y="180" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="540" y="180" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="680" y="180" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="810" y="180" width="100" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54"  y="198">Widget Pro</text>
+    <text x="290" y="198" text-anchor="end">2,450</text>
+    <text x="420" y="198" text-anchor="end">$18,375.00</text>
+    <text x="530" y="198" text-anchor="end" fill="#1a7f37" font-weight="600">▲ 12.40%</text>
+    <text x="554" y="198">12-Jan-2026</text>
+    <text x="694" y="198">A. Rahman</text>
+  </g>
+  <!-- status pill row 3 -->
+  <rect x="820" y="186" width="80" height="18" rx="9" fill="#d1f4dc" stroke="#1a7f37"/>
+  <text x="860" y="199" font-size="11" fill="#1a7f37" font-weight="700" text-anchor="middle">Active</text>
+
+  <!-- Row 4 (zebra grey) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="208" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="226" font-size="11" fill="#57606a" text-anchor="middle">4</text>
+    <rect x="40"  y="208" width="170" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="210" y="208" width="90"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="300" y="208" width="130" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="430" y="208" width="110" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="540" y="208" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="680" y="208" width="130" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="810" y="208" width="100" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="54"  y="226">Gadget Max</text>
+    <text x="290" y="226" text-anchor="end">1,820</text>
+    <text x="420" y="226" text-anchor="end">$24,934.00</text>
+    <text x="530" y="226" text-anchor="end" fill="#1a7f37" font-weight="600">▲ 8.75%</text>
+    <text x="554" y="226">03-Feb-2026</text>
+    <text x="694" y="226">P. Naidu</text>
+  </g>
+  <rect x="820" y="214" width="80" height="18" rx="9" fill="#d1f4dc" stroke="#1a7f37"/>
+  <text x="860" y="227" font-size="11" fill="#1a7f37" font-weight="700" text-anchor="middle">Active</text>
+
+  <!-- Row 5 (white) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="236" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="254" font-size="11" fill="#57606a" text-anchor="middle">5</text>
+    <rect x="40"  y="236" width="170" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="210" y="236" width="90"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="236" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="430" y="236" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="540" y="236" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="680" y="236" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="810" y="236" width="100" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54"  y="254">Contraption</text>
+    <text x="290" y="254" text-anchor="end">960</text>
+    <text x="420" y="254" text-anchor="end">$9,504.00</text>
+    <text x="530" y="254" text-anchor="end" fill="#cf222e" font-weight="600">▼ 3.20%</text>
+    <text x="554" y="254">21-Feb-2026</text>
+    <text x="694" y="254">S. Ali</text>
+  </g>
+  <rect x="820" y="242" width="80" height="18" rx="9" fill="#fff1e5" stroke="#bc4c00"/>
+  <text x="860" y="255" font-size="11" fill="#bc4c00" font-weight="700" text-anchor="middle">Review</text>
+
+  <!-- Row 6 (zebra grey) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="264" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="282" font-size="11" fill="#57606a" text-anchor="middle">6</text>
+    <rect x="40"  y="264" width="170" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="210" y="264" width="90"  height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="300" y="264" width="130" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="430" y="264" width="110" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="540" y="264" width="140" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="680" y="264" width="130" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <rect x="810" y="264" width="100" height="28" fill="#f3f6f9" stroke="#d0d7de"/>
+    <text x="54"  y="282">Gizmo Lite</text>
+    <text x="290" y="282" text-anchor="end">3,105</text>
+    <text x="420" y="282" text-anchor="end">$6,210.50</text>
+    <text x="530" y="282" text-anchor="end" fill="#1a7f37" font-weight="600">▲ 22.10%</text>
+    <text x="554" y="282">05-Mar-2026</text>
+    <text x="694" y="282">D. Wu</text>
+  </g>
+  <rect x="820" y="270" width="80" height="18" rx="9" fill="#d1f4dc" stroke="#1a7f37"/>
+  <text x="860" y="283" font-size="11" fill="#1a7f37" font-weight="700" text-anchor="middle">Active</text>
+
+  <!-- Row 7 (white) -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10"  y="292" width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="310" font-size="11" fill="#57606a" text-anchor="middle">7</text>
+    <rect x="40"  y="292" width="170" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="210" y="292" width="90"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="292" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="430" y="292" width="110" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="540" y="292" width="140" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="680" y="292" width="130" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="810" y="292" width="100" height="28" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54"  y="310">Legacy Kit</text>
+    <text x="290" y="310" text-anchor="end">410</text>
+    <text x="420" y="310" text-anchor="end">$2,050.00</text>
+    <text x="530" y="310" text-anchor="end" fill="#cf222e" font-weight="600">▼ 15.00%</text>
+    <text x="554" y="310">12-Nov-2024</text>
+    <text x="694" y="310">R. Khan</text>
+  </g>
+  <rect x="820" y="298" width="80" height="18" rx="9" fill="#ffebe9" stroke="#cf222e"/>
+  <text x="860" y="311" font-size="11" fill="#cf222e" font-weight="700" text-anchor="middle">Closed</text>
+
+  <!-- Row 8: Totals -->
+  <g font-size="12" fill="#0f2d5c" font-weight="700">
+    <rect x="10"  y="320" width="30"  height="30" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="339" font-size="11" fill="#57606a" text-anchor="middle">8</text>
+    <rect x="40"  y="320" width="170" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="210" y="320" width="90"  height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="300" y="320" width="130" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="430" y="320" width="110" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="540" y="320" width="140" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="680" y="320" width="130" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <rect x="810" y="320" width="100" height="30" fill="#e6eefc" stroke="#2d6cdf"/>
+    <text x="54"  y="340">TOTALS</text>
+    <text x="290" y="340" text-anchor="end">8,745</text>
+    <text x="420" y="340" text-anchor="end">$61,073.50</text>
+    <text x="530" y="340" text-anchor="end" fill="#1a7f37">▲ 5.01%</text>
+    <text x="554" y="340">—</text>
+    <text x="694" y="340">5 owners</text>
+    <text x="860" y="340" text-anchor="middle">4 / 5</text>
+  </g>
+
+  <!-- Comment indicator (red triangle on "Contraption" cell) -->
+  <polygon points="205,237 210,237 210,242" fill="#cf222e"/>
+
+  <!-- Sheet tabs -->
+  <rect x="10" y="480" width="900" height="30" fill="#f6f8fa" stroke="#d0d7de"/>
+  <rect x="20" y="482" width="90"  height="28" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="65" y="500" font-size="12" fill="#0d4ba1" font-weight="700" text-anchor="middle">Summary</text>
+  <rect x="110" y="482" width="90" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="155" y="500" font-size="12" fill="#24292f" text-anchor="middle">Products</text>
+  <rect x="200" y="482" width="90" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="245" y="500" font-size="12" fill="#24292f" text-anchor="middle">Regions</text>
+  <rect x="290" y="482" width="90" height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="335" y="500" font-size="12" fill="#24292f" text-anchor="middle">Raw Data</text>
+
+  <!-- Freeze marker -->
+  <line x1="40" y1="180" x2="910" y2="180" stroke="#2d6cdf" stroke-width="0.8" stroke-dasharray="4,2" opacity="0.6"/>
+  <text x="905" y="175" font-size="9" fill="#2d6cdf" text-anchor="end" font-weight="700">↑ header frozen</text>
+
+  <!-- Callout: generated by library -->
+  <g>
+    <rect x="450" y="385" width="440" height="82" rx="8" fill="#fff" stroke="#d0d7de" filter="url(#shadow)"/>
+    <text x="466" y="405" font-size="12" fill="#24292f" font-weight="700">Generated in 5 lines:</text>
+    <text x="466" y="424" font-size="11" fill="#57606a" font-family="Consolas, monospace">ReportBuilder.on(sheet)</text>
+    <text x="466" y="438" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .title("Q3 Sales Report — Regional Breakdown")</text>
+    <text x="466" y="452" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .rowsFromBeans(products)</text>
+    <text x="466" y="466" font-size="11" fill="#57606a" font-family="Consolas, monospace">    .zebraStripes(true).freezeHeader(true).autoFilter(true).render();</text>
+  </g>
+
+  <!-- Feature callouts -->
+  <g font-size="10.5" fill="#0d4ba1" font-weight="600">
+    <text x="30"  y="385">✓ Colored title</text>
+    <text x="30"  y="403">✓ Styled headers</text>
+    <text x="30"  y="421">✓ Zebra striping</text>
+    <text x="30"  y="439">✓ Frozen header row</text>
+    <text x="30"  y="457">✓ Auto-filter dropdowns</text>
+    <text x="220" y="385">✓ Number formats (qty)</text>
+    <text x="220" y="403">✓ Currency formatting</text>
+    <text x="220" y="421">✓ Percent + trend color</text>
+    <text x="220" y="439">✓ Date formatting</text>
+    <text x="220" y="457">✓ Status pills + totals</text>
+  </g>
+</svg>

--- a/docs/row-array-preview.svg
+++ b/docs/row-array-preview.svg
@@ -1,0 +1,145 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 540" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="760" height="520" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="760" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="760" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">rowFromArray.xlsx — Shopping</text>
+
+  <!-- Column letters -->
+  <g font-size="11" fill="#57606a" text-anchor="middle">
+    <rect x="10"  y="54" width="30"  height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="40"  y="54" width="180" height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="220" y="54" width="80"  height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="300" y="54" width="100" height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="400" y="54" width="140" height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="68">#</text>
+    <text x="130" y="68">A</text>
+    <text x="260" y="68">B</text>
+    <text x="350" y="68">C</text>
+    <text x="470" y="68">D</text>
+  </g>
+
+  <!-- Row 1: Title (merged A1:D1) -->
+  <rect x="10" y="74"  width="30"  height="28" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="92" font-size="11" fill="#57606a" text-anchor="middle">1</text>
+  <rect x="40" y="74"  width="500" height="28" fill="#2d6cdf" stroke="#000"/>
+  <text x="290" y="93" font-size="14" font-weight="700" fill="#ffffff" text-anchor="middle">Weekly Shopping List</text>
+
+  <!-- Row 2: Header row from String[] - BLUE -->
+  <rect x="10" y="102" width="30"  height="26" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="119" font-size="11" fill="#57606a" text-anchor="middle">2</text>
+  <g font-size="12" fill="#ffffff" font-weight="700" text-anchor="middle">
+    <rect x="40"  y="102" width="180" height="26" fill="#2d6cdf" stroke="#000"/>
+    <rect x="220" y="102" width="80"  height="26" fill="#2d6cdf" stroke="#000"/>
+    <rect x="300" y="102" width="100" height="26" fill="#2d6cdf" stroke="#000"/>
+    <rect x="400" y="102" width="140" height="26" fill="#2d6cdf" stroke="#000"/>
+    <text x="130" y="120">Item</text>
+    <text x="260" y="120">Qty</text>
+    <text x="350" y="120">Unit</text>
+    <text x="470" y="120">Aisle</text>
+  </g>
+
+  <!-- Arrow calling out the header array -->
+  <path d="M 548 115 L 605 115" stroke="#cf222e" stroke-width="1.4" fill="none" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+      <polygon points="0,0 8,4 0,8" fill="#cf222e"/>
+    </marker>
+  </defs>
+  <rect x="608" y="98" width="155" height="36" rx="4" fill="#fff5f5" stroke="#cf222e"/>
+  <text x="616" y="113" font-size="10.5" fill="#cf222e" font-weight="700">String[] headers</text>
+  <text x="616" y="127" font-size="10" fill="#57606a" font-family="Consolas, monospace">setRowValues(headers)</text>
+
+  <!-- Data rows -->
+  <g font-size="12" fill="#24292f">
+    <rect x="10" y="128" width="30" height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25" y="144" font-size="11" fill="#57606a" text-anchor="middle">3</text>
+    <rect x="40"  y="128" width="180" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="220" y="128" width="80"  height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="128" width="100" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="400" y="128" width="140" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54" y="144">Apples</text>
+    <text x="290" y="144" text-anchor="end">6</text>
+    <text x="314" y="144">pcs</text>
+    <text x="414" y="144">Produce</text>
+
+    <rect x="10" y="152" width="30" height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25" y="168" font-size="11" fill="#57606a" text-anchor="middle">4</text>
+    <rect x="40"  y="152" width="180" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="220" y="152" width="80"  height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="152" width="100" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="400" y="152" width="140" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54" y="168">Milk</text>
+    <text x="290" y="168" text-anchor="end">2</text>
+    <text x="314" y="168">L</text>
+    <text x="414" y="168">Dairy</text>
+
+    <rect x="10" y="176" width="30" height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25" y="192" font-size="11" fill="#57606a" text-anchor="middle">5</text>
+    <rect x="40"  y="176" width="180" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="220" y="176" width="80"  height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="176" width="100" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="400" y="176" width="140" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54" y="192">Bread</text>
+    <text x="290" y="192" text-anchor="end">1</text>
+    <text x="314" y="192">loaf</text>
+    <text x="414" y="192">Bakery</text>
+
+    <rect x="10" y="200" width="30" height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25" y="216" font-size="11" fill="#57606a" text-anchor="middle">6</text>
+    <rect x="40"  y="200" width="180" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="220" y="200" width="80"  height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="200" width="100" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="400" y="200" width="140" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54" y="216">Coffee</text>
+    <text x="290" y="216" text-anchor="end">1</text>
+    <text x="314" y="216">kg</text>
+    <text x="414" y="216">Grocery</text>
+
+    <rect x="10" y="224" width="30" height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25" y="240" font-size="11" fill="#57606a" text-anchor="middle">7</text>
+    <rect x="40"  y="224" width="180" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="220" y="224" width="80"  height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="300" y="224" width="100" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <rect x="400" y="224" width="140" height="24" fill="#ffffff" stroke="#d0d7de"/>
+    <text x="54" y="240">Eggs</text>
+    <text x="290" y="240" text-anchor="end">12</text>
+    <text x="314" y="240">pcs</text>
+    <text x="414" y="240">Dairy</text>
+  </g>
+
+  <!-- Callout for data rows -->
+  <path d="M 548 212 L 605 212" stroke="#1a7f37" stroke-width="1.4" fill="none"/>
+  <polygon points="605,208 605,216 612,212" fill="#1a7f37"/>
+  <rect x="608" y="195" width="155" height="36" rx="4" fill="#eef7f0" stroke="#1a7f37"/>
+  <text x="616" y="210" font-size="10.5" fill="#1a7f37" font-weight="700">Object[] (mixed types)</text>
+  <text x="616" y="224" font-size="10" fill="#57606a" font-family="Consolas, monospace">setValues(new Object[]...)</text>
+
+  <!-- Code callout -->
+  <rect x="40" y="275" width="700" height="245" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="295" font-size="12" fill="#24292f" font-weight="700">examples/RowFromArrayExample.java — write rows in one call</text>
+
+  <text x="56" y="320" font-size="11" fill="#cf222e" font-family="Consolas, monospace" font-weight="700">// 1. Header row from a String[]</text>
+  <text x="56" y="336" font-size="11" fill="#57606a" font-family="Consolas, monospace">String[] headers = {"Item", "Qty", "Unit", "Aisle"};</text>
+  <text x="56" y="352" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(2).setRowValues(headers);</text>
+  <text x="56" y="368" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(2).applyStyle(ExcelStyle.header());</text>
+
+  <text x="56" y="395" font-size="11" fill="#1a7f37" font-family="Consolas, monospace" font-weight="700">// 2. Data rows from Object[] — mixed types</text>
+  <text x="56" y="411" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(3).setValues(new Object[]{"Apples",  6, "pcs",  "Produce"});</text>
+  <text x="56" y="427" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(4).setValues(new Object[]{"Milk",    2, "L",    "Dairy"});</text>
+  <text x="56" y="443" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(5).setValues(new Object[]{"Bread",   1, "loaf", "Bakery"});</text>
+  <text x="56" y="459" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(6).setValues(new Object[]{"Coffee",  1, "kg",   "Grocery"});</text>
+  <text x="56" y="475" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(7).setValues(new Object[]{"Eggs",   12, "pcs",  "Dairy"});</text>
+
+  <text x="56" y="505" font-size="10.5" fill="#636363" font-style="italic">One call writes the whole row — cells are created, types routed automatically.</text>
+</svg>

--- a/docs/title-content-preview.svg
+++ b/docs/title-content-preview.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 440" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="680" height="420" rx="6" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <!-- Window chrome -->
+  <rect x="10" y="10" width="680" height="32" rx="6" fill="#0d4ba1"/>
+  <rect x="10" y="30" width="680" height="12" fill="#0d4ba1"/>
+  <circle cx="28" cy="26" r="5" fill="#ff5f57"/>
+  <circle cx="44" cy="26" r="5" fill="#febc2e"/>
+  <circle cx="60" cy="26" r="5" fill="#28c840"/>
+  <text x="82" y="30" fill="#ffffff" font-size="13" font-weight="600">titleContent.xlsx — Notes</text>
+
+  <!-- Column letters -->
+  <g font-size="11" fill="#57606a" text-anchor="middle">
+    <rect x="10"  y="54" width="30"  height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect x="40"  y="54" width="610" height="20" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="25"  y="68">#</text>
+    <text x="345" y="68">A</text>
+  </g>
+
+  <!-- Title (merged) -->
+  <rect x="10" y="74"  width="30"  height="30" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="93" font-size="11" fill="#57606a" text-anchor="middle">1</text>
+  <rect x="40" y="74"  width="650" height="30" fill="#2d6cdf" stroke="#000"/>
+  <text x="365" y="94" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">Project Kickoff — 2026 Roadmap</text>
+
+  <!-- Empty row 2 -->
+  <rect x="10" y="104" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="120" font-size="11" fill="#57606a" text-anchor="middle">2</text>
+  <rect x="40" y="104" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+
+  <!-- Row 3: Goals header -->
+  <rect x="10" y="126" width="30"  height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="143" font-size="11" fill="#57606a" text-anchor="middle">3</text>
+  <rect x="40" y="126" width="650" height="24" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="144" font-size="13" font-weight="700" fill="#24292f">Goals</text>
+
+  <!-- Goals bullets -->
+  <rect x="10" y="150" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="166" font-size="11" fill="#57606a" text-anchor="middle">4</text>
+  <rect x="40" y="150" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="166" font-size="12" fill="#24292f">• Migrate all clients to the v2 API</text>
+
+  <rect x="10" y="172" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="188" font-size="11" fill="#57606a" text-anchor="middle">5</text>
+  <rect x="40" y="172" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="188" font-size="12" fill="#24292f">• Cut average latency by 30%</text>
+
+  <rect x="10" y="194" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="210" font-size="11" fill="#57606a" text-anchor="middle">6</text>
+  <rect x="40" y="194" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="210" font-size="12" fill="#24292f">• Launch mobile SDK in Q3</text>
+
+  <!-- Empty row 7 -->
+  <rect x="10" y="216" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="232" font-size="11" fill="#57606a" text-anchor="middle">7</text>
+  <rect x="40" y="216" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+
+  <!-- Row 8: Owners header -->
+  <rect x="10" y="238" width="30"  height="24" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="255" font-size="11" fill="#57606a" text-anchor="middle">8</text>
+  <rect x="40" y="238" width="650" height="24" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="256" font-size="13" font-weight="700" fill="#24292f">Owners</text>
+
+  <!-- Owners bullets -->
+  <rect x="10" y="262" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="278" font-size="11" fill="#57606a" text-anchor="middle">9</text>
+  <rect x="40" y="262" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="278" font-size="12" fill="#24292f">• Engineering — John Smith</text>
+
+  <rect x="10" y="284" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="300" font-size="11" fill="#57606a" text-anchor="middle">10</text>
+  <rect x="40" y="284" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="300" font-size="12" fill="#24292f">• Product — Amina Khan</text>
+
+  <rect x="10" y="306" width="30"  height="22" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="25" y="322" font-size="11" fill="#57606a" text-anchor="middle">11</text>
+  <rect x="40" y="306" width="650" height="22" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="54" y="322" font-size="12" fill="#24292f">• Design — John Jones</text>
+
+  <!-- Code callout -->
+  <rect x="40" y="345" width="645" height="75" rx="6" fill="#fff" stroke="#d0d7de"/>
+  <text x="56" y="363" font-size="12" fill="#24292f" font-weight="700">examples/TitleAndContentExample.java — simplest possible styled workbook</text>
+  <text x="56" y="383" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.cell(1,1).setText("Project Kickoff — 2026 Roadmap");</text>
+  <text x="56" y="399" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.mergeCells(1, 1, 1, 4);</text>
+  <text x="56" y="415" font-size="11" fill="#57606a" font-family="Consolas, monospace">sh.row(1).applyStyle(ExcelStyle.header(), 1, 5);</text>
+</svg>

--- a/examples/CollectionReportExample.java
+++ b/examples/CollectionReportExample.java
@@ -53,6 +53,7 @@ public class CollectionReportExample {
                 new Product("A-103", "Contraption", 42, 99.99, 0.15));
 
         ExcelWorkSheet catalog = wb.addSheet("Catalog");
+        catalog.activate();   // show this sheet by default when the file is opened
         ReportBuilder.on(catalog)
                 .title("Product Catalog — Q3")
                 .rowsFromBeans(products)

--- a/examples/CollectionReportExample.java
+++ b/examples/CollectionReportExample.java
@@ -1,0 +1,99 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelColumn;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+import solutions.bismi.excel.ReportBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end demo of collection-driven report generation.
+ *
+ * <p>Shows three user-friendly paths to a styled workbook:
+ * <ol>
+ *   <li>Sheet 1 — {@link ReportBuilder} driven by a {@code List<Bean>} with
+ *       {@link ExcelColumn} annotations</li>
+ *   <li>Sheet 2 — {@link ReportBuilder} driven by a {@code List<Map>} with
+ *       zebra striping, frozen header, auto-filter</li>
+ *   <li>Sheet 3 — Direct {@link ExcelWorkSheet#writeMaps} for the simplest case</li>
+ * </ol>
+ * None of the user code touches {@code CellStyle}, {@code XSSFWorkbook}, or
+ * raw POI constants.</p>
+ */
+public class CollectionReportExample {
+
+    public static class Product {
+        @ExcelColumn(name = "SKU",      order = 1)                               String sku;
+        @ExcelColumn(name = "Item",     order = 2)                               String name;
+        @ExcelColumn(name = "Units",    order = 3, format = "#,##0")             int units;
+        @ExcelColumn(name = "Price",    order = 4, format = "$#,##0.00")         double price;
+        @ExcelColumn(name = "Discount", order = 5, format = "0.00%")             double discount;
+
+        public Product() { }
+        public Product(String sku, String name, int units, double price, double discount) {
+            this.sku = sku; this.name = name; this.units = units;
+            this.price = price; this.discount = discount;
+        }
+    }
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/collectionReport.xlsx");
+
+        // ---------- Sheet 1: annotated beans ----------
+        List<Product> products = Arrays.asList(
+                new Product("A-100", "Widget",   120, 12.50, 0.05),
+                new Product("A-101", "Gadget",    85, 24.00, 0.10),
+                new Product("A-102", "Gizmo",    210,  6.75, 0.00),
+                new Product("A-103", "Contraption", 42, 99.99, 0.15));
+
+        ExcelWorkSheet catalog = wb.addSheet("Catalog");
+        ReportBuilder.on(catalog)
+                .title("Product Catalog — Q3")
+                .rowsFromBeans(products)
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .render();
+
+        // ---------- Sheet 2: List<Map> + custom column styling ----------
+        List<Map<String, Object>> sales = new ArrayList<>();
+        sales.add(row("North", 120, 1500.00));
+        sales.add(row("South",  85,  920.50));
+        sales.add(row("East",  210, 2750.00));
+        sales.add(row("West",   42,  499.95));
+
+        ExcelWorkSheet salesSheet = wb.addSheet("Sales");
+        ReportBuilder.on(salesSheet)
+                .title("Regional Sales Summary")
+                .rowsFromMaps(sales)
+                .columnStyle(3, ExcelStyle.currency())
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .render();
+
+        // ---------- Sheet 3: bare-minimum writeMaps ----------
+        ExcelWorkSheet raw = wb.addSheet("Raw");
+        raw.writeMaps(sales)
+           .freezePane(2, 1)
+           .autoSizeAllColumns();
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("Report written to ./resources/testdata/collectionReport.xlsx");
+    }
+
+    private static Map<String, Object> row(String region, int units, double revenue) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("Region", region);
+        m.put("Units", units);
+        m.put("Revenue", revenue);
+        return m;
+    }
+}

--- a/examples/DashboardExample.java
+++ b/examples/DashboardExample.java
@@ -1,0 +1,132 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelColumn;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+import solutions.bismi.excel.ReportBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Executive dashboard — KPI tiles on one sheet, a top-products table on another,
+ * and raw data on a third. Demonstrates:
+ *
+ * <ul>
+ *   <li>Multiple {@link ExcelStyle} reused for KPI tiles (coloured backgrounds, centred)</li>
+ *   <li>Cell merging to build "tile" layouts</li>
+ *   <li>{@link ReportBuilder} with zebra / freeze / filter on the top-products sheet</li>
+ *   <li>Column-style overrides for currency and percent</li>
+ * </ul>
+ */
+public class DashboardExample {
+
+    public static class ProductPerf {
+        @ExcelColumn(name = "Product", order = 1)                                 String product;
+        @ExcelColumn(name = "Region",  order = 2)                                 String region;
+        @ExcelColumn(name = "Revenue", order = 3, format = "$#,##0.00")           double revenue;
+        @ExcelColumn(name = "Margin",  order = 4, format = "0.00%")               double margin;
+
+        public ProductPerf() {}
+        public ProductPerf(String product, String region, double revenue, double margin) {
+            this.product = product; this.region = region;
+            this.revenue = revenue; this.margin = margin;
+        }
+    }
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/dashboard.xlsx");
+
+        buildSummary(wb);
+        buildTopProducts(wb);
+        buildRawData(wb);
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("Dashboard written to ./resources/testdata/dashboard.xlsx");
+    }
+
+    private static void buildSummary(ExcelWorkBook wb) {
+        ExcelWorkSheet sh = wb.addSheet("Summary");
+        sh.activate();
+
+        ExcelStyle title = ExcelStyle.builder()
+                .bold(true).fontColor("white").fillColor("#0d4ba1")
+                .horizontalAlignment("CENTER").build();
+
+        sh.cell(1, 1).setText("Q3 Executive Dashboard");
+        sh.mergeCells(1, 1, 1, 8);
+        sh.row(1).applyStyle(title, 1, 9);
+
+        kpiTile(sh, 3, 1, "REVENUE",       "$1,248,500", "#1a7f37");
+        kpiTile(sh, 3, 3, "ORDERS",        "4,812",      "#2d6cdf");
+        kpiTile(sh, 3, 5, "NEW CUSTOMERS", "1,203",      "#bc4c00");
+        kpiTile(sh, 3, 7, "RETURN RATE",   "2.4%",       "#cf222e");
+
+        sh.cell(7, 1).setText("Highlights").setFontStyle(true, false, false);
+        sh.cell(8, 1).setText("• Widget Pro led revenue at $18,375");
+        sh.cell(9, 1).setText("• North region grew 12.4% QoQ");
+        sh.cell(10, 1).setText("• Legacy Kit flagged for review");
+
+        for (int c = 1; c <= 8; c++) sh.setColumnWidth(c, 14);
+    }
+
+    private static void kpiTile(ExcelWorkSheet sh, int row, int col, String label, String value, String color) {
+        ExcelStyle labelStyle = ExcelStyle.builder()
+                .bold(true).fontColor("white").fillColor(color)
+                .horizontalAlignment("CENTER").build();
+        ExcelStyle valueStyle = ExcelStyle.builder()
+                .bold(true).fillColor("grey_25_percent")
+                .horizontalAlignment("CENTER").fullBorder("black").build();
+
+        sh.cell(row, col).setText(label);
+        sh.mergeCells(row, col, row, col + 1);
+        sh.row(row).applyStyle(labelStyle, col, col + 2);
+
+        sh.cell(row + 1, col).setText(value);
+        sh.mergeCells(row + 1, col, row + 2, col + 1);
+        sh.row(row + 1).applyStyle(valueStyle, col, col + 2);
+        sh.row(row + 2).applyStyle(valueStyle, col, col + 2);
+    }
+
+    private static void buildTopProducts(ExcelWorkBook wb) {
+        ExcelWorkSheet sh = wb.addSheet("TopProducts");
+
+        List<ProductPerf> data = Arrays.asList(
+                new ProductPerf("Widget Pro",  "North",  18375.00, 0.284),
+                new ProductPerf("Gadget Max",  "East",   24934.00, 0.221),
+                new ProductPerf("Contraption", "West",    9504.00, 0.157),
+                new ProductPerf("Gizmo Lite",  "South",   6210.50, 0.312),
+                new ProductPerf("Flagship X",  "North",  31240.00, 0.402));
+
+        ReportBuilder.on(sh)
+                .title("Top Products by Revenue")
+                .rowsFromBeans(data)
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .render();
+    }
+
+    private static void buildRawData(ExcelWorkBook wb) {
+        ExcelWorkSheet sh = wb.addSheet("RawData");
+        String[] headers = {"Order#", "Date", "Product", "Qty", "Amount"};
+        sh.row(1).setRowValues(headers);
+        sh.row(1).applyStyle(ExcelStyle.header());
+
+        Object[][] orders = {
+                {"ORD-1001", java.time.LocalDate.of(2026, 1, 5),  "Widget Pro",  12, 1800.00},
+                {"ORD-1002", java.time.LocalDate.of(2026, 1, 7),  "Gadget Max",   5, 1200.00},
+                {"ORD-1003", java.time.LocalDate.of(2026, 1, 11), "Flagship X",   2, 7800.00},
+                {"ORD-1004", java.time.LocalDate.of(2026, 1, 14), "Gizmo Lite",  40,  800.00},
+                {"ORD-1005", java.time.LocalDate.of(2026, 1, 18), "Contraption",  3,  900.00},
+        };
+        for (int i = 0; i < orders.length; i++) {
+            sh.row(i + 2).setValues(orders[i]);
+            sh.cell(i + 2, 2).setNumberFormat("dd-MMM-yyyy");
+            sh.cell(i + 2, 5).applyStyle(ExcelStyle.currency());
+        }
+        sh.freezePane(2, 1).enableAutoFilter(1, 1, headers.length).autoSizeAllColumns();
+    }
+}

--- a/examples/EmployeeDirectoryExample.java
+++ b/examples/EmployeeDirectoryExample.java
@@ -49,7 +49,7 @@ public class EmployeeDirectoryExample {
                 new Employee(102, "Rahul Menon",   "Senior Engineer",  "rahul.menon@example.com",  LocalDate.of(2019, 3, 4), 135000, true),
                 new Employee(103, "Sofia Gomez",   "Product Manager",  "sofia.gomez@example.com",  LocalDate.of(2022, 11, 21),110000, true),
                 new Employee(104, "Dmitri Ivanov", "QA Lead",          "dmitri.ivanov@example.com",LocalDate.of(2018, 1, 9), 120000, false),
-                new Employee(105, "Priya Naidu",   "Designer",         "priya.naidu@example.com",  LocalDate.of(2023, 6, 15),  88000, true));
+                new Employee(105, "John Jones",    "Designer",         "john.jones@example.com",   LocalDate.of(2023, 6, 15),  88000, true));
 
         // No title() — keeps row 1 as the header so readAsBeans works cleanly later.
         ReportBuilder.on(sh)

--- a/examples/EmployeeDirectoryExample.java
+++ b/examples/EmployeeDirectoryExample.java
@@ -1,0 +1,89 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelColumn;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+import solutions.bismi.excel.ReportBuilder;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Staff directory built from a {@code List<Employee>}. Demonstrates:
+ *
+ * <ul>
+ *   <li>{@link ExcelColumn} annotations for header, order, format</li>
+ *   <li>{@link ReportBuilder} — zebra striping, frozen header, auto-filter, per-column currency</li>
+ *   <li>Post-render enrichment: clickable email hyperlinks and a cell comment</li>
+ *   <li>Round-trip: read the saved file back into a {@code List<Employee>} via {@code readAsBeans}</li>
+ * </ul>
+ */
+public class EmployeeDirectoryExample {
+
+    public static class Employee {
+        @ExcelColumn(name = "Id",      order = 1)                              int        id;
+        @ExcelColumn(name = "Name",    order = 2)                              String     name;
+        @ExcelColumn(name = "Role",    order = 3)                              String     role;
+        @ExcelColumn(name = "Email",   order = 4)                              String     email;
+        @ExcelColumn(name = "Joined",  order = 5, format = "dd-MMM-yyyy")      LocalDate  joined;
+        @ExcelColumn(name = "Salary",  order = 6, format = "$#,##0")           double     salary;
+        @ExcelColumn(name = "Active",  order = 7)                              boolean    active;
+
+        public Employee() {}
+        public Employee(int id, String name, String role, String email, LocalDate joined, double salary, boolean active) {
+            this.id = id; this.name = name; this.role = role; this.email = email;
+            this.joined = joined; this.salary = salary; this.active = active;
+        }
+    }
+
+    public static void main(String[] args) {
+        String path = "./resources/testdata/employees.xlsx";
+
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("Directory");
+
+        List<Employee> staff = Arrays.asList(
+                new Employee(101, "Amina Khan",    "Engineer",         "amina.khan@example.com",   LocalDate.of(2021, 7, 12),  95000, true),
+                new Employee(102, "Rahul Menon",   "Senior Engineer",  "rahul.menon@example.com",  LocalDate.of(2019, 3, 4), 135000, true),
+                new Employee(103, "Sofia Gomez",   "Product Manager",  "sofia.gomez@example.com",  LocalDate.of(2022, 11, 21),110000, true),
+                new Employee(104, "Dmitri Ivanov", "QA Lead",          "dmitri.ivanov@example.com",LocalDate.of(2018, 1, 9), 120000, false),
+                new Employee(105, "Priya Naidu",   "Designer",         "priya.naidu@example.com",  LocalDate.of(2023, 6, 15),  88000, true));
+
+        // No title() — keeps row 1 as the header so readAsBeans works cleanly later.
+        ReportBuilder.on(sh)
+                .rowsFromBeans(staff)
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .render();
+
+        int emailCol = 4;
+        for (int r = 0; r < staff.size(); r++) {
+            int row = r + 2;
+            sh.cell(row, emailCol).setHyperlink("mailto:" + staff.get(r).email, staff.get(r).email);
+        }
+
+        sh.cell(2, 2).setComment("Go-to for onboarding questions", "HR Team");
+
+        ExcelStyle inactive = ExcelStyle.builder()
+                .fontColor("grey_50_percent").italic(true).build();
+        for (int r = 0; r < staff.size(); r++) {
+            if (!staff.get(r).active) {
+                int row = r + 2;
+                sh.row(row).applyStyle(inactive, 1, 8);
+            }
+        }
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+
+        ExcelApplication app2 = new ExcelApplication();
+        ExcelWorkBook wb2 = app2.openWorkbook(path);
+        List<Employee> read = wb2.getExcelSheet("Directory").readAsBeans(Employee.class);
+        System.out.printf("Read back %d employees; first is %s (%s)%n",
+                read.size(), read.get(0).name, read.get(0).role);
+        app2.closeAllWorkBooks();
+    }
+}

--- a/examples/EmployeeDirectoryExample.java
+++ b/examples/EmployeeDirectoryExample.java
@@ -43,6 +43,7 @@ public class EmployeeDirectoryExample {
         ExcelApplication app = new ExcelApplication();
         ExcelWorkBook wb = app.createWorkBook(path);
         ExcelWorkSheet sh = wb.addSheet("Directory");
+        sh.activate();   // show this sheet by default when the file is opened
 
         List<Employee> staff = Arrays.asList(
                 new Employee(101, "Amina Khan",    "Engineer",         "amina.khan@example.com",   LocalDate.of(2021, 7, 12),  95000, true),

--- a/examples/InvoiceExample.java
+++ b/examples/InvoiceExample.java
@@ -27,8 +27,8 @@ public class InvoiceExample {
         ExcelStyle labelStyle = ExcelStyle.builder()
                 .bold(true).fontColor("#0d4ba1").build();
         ExcelStyle addressStyle = ExcelStyle.builder()
-                .fillColor("grey_25_percent").build();
-        ExcelStyle headerStyle = ExcelStyle.header();
+                .fillColor("#ebeef2").build();
+        ExcelStyle headerStyle = ExcelStyle.greyHeader();
         ExcelStyle money = ExcelStyle.currency();
         ExcelStyle totalRow = ExcelStyle.builder()
                 .bold(true).fillColor("#e6eefc").numberFormat("$#,##0.00")
@@ -46,8 +46,8 @@ public class InvoiceExample {
 
         sh.cell(5, 1).setText("From").applyStyle(labelStyle);
         sh.cell(6, 1).setText("Bismi Solutions").applyStyle(addressStyle);
-        sh.cell(7, 1).setText("Tech Park, Level 4").applyStyle(addressStyle);
-        sh.cell(8, 1).setText("Chennai, India 600001").applyStyle(addressStyle);
+        sh.cell(7, 1).setText("Infopark, Phase II").applyStyle(addressStyle);
+        sh.cell(8, 1).setText("Kochi, India 682042").applyStyle(addressStyle);
 
         sh.cell(5, 4).setText("Bill To").applyStyle(labelStyle);
         sh.cell(6, 4).setText("Acme Corp.").applyStyle(addressStyle);

--- a/examples/InvoiceExample.java
+++ b/examples/InvoiceExample.java
@@ -20,6 +20,7 @@ public class InvoiceExample {
         ExcelApplication app = new ExcelApplication();
         ExcelWorkBook wb = app.createWorkBook("./resources/testdata/invoice.xlsx");
         ExcelWorkSheet sh = wb.addSheet("Invoice");
+        sh.activate();   // show this sheet by default when the file is opened
 
         ExcelStyle titleStyle = ExcelStyle.builder()
                 .bold(true).fontColor("white").fillColor("#0d4ba1")

--- a/examples/InvoiceExample.java
+++ b/examples/InvoiceExample.java
@@ -1,0 +1,96 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+
+/**
+ * Produces a one-page invoice styled with merged header, bill-to block, line items,
+ * subtotal / tax / total. Demonstrates:
+ *
+ * <ul>
+ *   <li>Merged title across columns</li>
+ *   <li>Reusable {@link ExcelStyle} for labels, currency, totals</li>
+ *   <li>Mixed-type row values via {@code setValues(Object[])}</li>
+ *   <li>Formulas for line totals and subtotal</li>
+ * </ul>
+ */
+public class InvoiceExample {
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/invoice.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("Invoice");
+
+        ExcelStyle titleStyle = ExcelStyle.builder()
+                .bold(true).fontColor("white").fillColor("#0d4ba1")
+                .horizontalAlignment("CENTER").build();
+        ExcelStyle labelStyle = ExcelStyle.builder()
+                .bold(true).fontColor("#0d4ba1").build();
+        ExcelStyle addressStyle = ExcelStyle.builder()
+                .fillColor("grey_25_percent").build();
+        ExcelStyle headerStyle = ExcelStyle.header();
+        ExcelStyle money = ExcelStyle.currency();
+        ExcelStyle totalRow = ExcelStyle.builder()
+                .bold(true).fillColor("#e6eefc").numberFormat("$#,##0.00")
+                .horizontalAlignment("RIGHT").fullBorder("black").build();
+
+        sh.cell(1, 1).setText("INVOICE");
+        sh.mergeCells(1, 1, 1, 5);
+        sh.row(1).applyStyle(titleStyle, 1, 6);
+
+        sh.cell(3, 1).setText("Invoice #:").applyStyle(labelStyle);
+        sh.cell(3, 2).setText("INV-2026-0042");
+        sh.cell(3, 4).setText("Date:").applyStyle(labelStyle);
+        sh.cell(3, 5).setValue(java.time.LocalDate.of(2026, 4, 21))
+                      .setNumberFormat("dd-MMM-yyyy");
+
+        sh.cell(5, 1).setText("From").applyStyle(labelStyle);
+        sh.cell(6, 1).setText("Bismi Solutions").applyStyle(addressStyle);
+        sh.cell(7, 1).setText("Tech Park, Level 4").applyStyle(addressStyle);
+        sh.cell(8, 1).setText("Chennai, India 600001").applyStyle(addressStyle);
+
+        sh.cell(5, 4).setText("Bill To").applyStyle(labelStyle);
+        sh.cell(6, 4).setText("Acme Corp.").applyStyle(addressStyle);
+        sh.cell(7, 4).setText("123 Market Street").applyStyle(addressStyle);
+        sh.cell(8, 4).setText("New York, NY 10001").applyStyle(addressStyle);
+
+        String[] headers = {"Qty", "Description", "Unit Price", "Total"};
+        sh.row(10).setRowValues(headers);
+        sh.row(10).applyStyle(headerStyle, 1, 5);
+
+        Object[][] items = {
+                {5,  "Excel library — enterprise licence",  299.00},
+                {12, "Premium support — hours",              150.00},
+                {1,  "Onsite training day",                 1200.00},
+                {3,  "Custom reporting setup",               450.00},
+        };
+        int startRow = 11;
+        for (int i = 0; i < items.length; i++) {
+            int r = startRow + i;
+            sh.row(r).setValues(new Object[]{items[i][0], items[i][1], items[i][2]});
+            sh.cell(r, 4).setFormula("A" + r + "*C" + r);
+            sh.cell(r, 3).applyStyle(money);
+            sh.cell(r, 4).applyStyle(money);
+        }
+
+        int totalsRow = startRow + items.length + 1;
+        sh.cell(totalsRow,     3).setText("Subtotal").applyStyle(labelStyle);
+        sh.cell(totalsRow,     4).setFormula("SUM(D" + startRow + ":D" + (totalsRow - 2) + ")")
+                                  .applyStyle(money);
+        sh.cell(totalsRow + 1, 3).setText("Tax (8%)").applyStyle(labelStyle);
+        sh.cell(totalsRow + 1, 4).setFormula("D" + totalsRow + "*0.08").applyStyle(money);
+        sh.cell(totalsRow + 2, 3).setText("TOTAL").applyStyle(totalRow);
+        sh.cell(totalsRow + 2, 4).setFormula("D" + totalsRow + "+D" + (totalsRow + 1))
+                                  .applyStyle(totalRow);
+
+        sh.setColumnWidth(1, 12);
+        sh.setColumnWidth(2, 40);
+        sh.setColumnWidth(3, 16);
+        sh.setColumnWidth(4, 16);
+        sh.setColumnWidth(5, 14);
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("Invoice written to ./resources/testdata/invoice.xlsx");
+    }
+}

--- a/examples/KpiTilesExample.java
+++ b/examples/KpiTilesExample.java
@@ -1,0 +1,46 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+
+/**
+ * Beginner-friendly dashboard: just four colour-coded KPI tiles on one sheet.
+ * No beans, no annotations, no loops — ~15 meaningful lines of code.
+ *
+ * <p>For the full three-sheet version with a data table and raw data, see
+ * {@code DashboardExample}.</p>
+ */
+public class KpiTilesExample {
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/kpiTiles.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("KPIs");
+        sh.activate();
+
+        sh.cell(1, 1).setText("Q3 Snapshot");
+        sh.mergeCells(1, 1, 1, 4);
+        sh.row(1).applyStyle(ExcelStyle.header(), 1, 5);
+
+        kpi(sh, 1, "Revenue",       "$1,248,500", "#1a7f37");   // green
+        kpi(sh, 2, "Orders",        "4,812",      "#2d6cdf");   // blue
+        kpi(sh, 3, "New Customers", "1,203",      "#bc4c00");   // orange
+        kpi(sh, 4, "Return Rate",   "2.4%",       "#cf222e");   // red
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("KPI tiles written to ./resources/testdata/kpiTiles.xlsx");
+    }
+
+    private static void kpi(ExcelWorkSheet sh, int col, String label, String value, String colour) {
+        ExcelStyle labelStyle = ExcelStyle.builder()
+                .fillColor(colour).fontColor("white").bold(true)
+                .horizontalAlignment("CENTER").build();
+        ExcelStyle valueStyle = ExcelStyle.builder()
+                .bold(true).horizontalAlignment("CENTER").fullBorder("black").build();
+
+        sh.cell(3, col).setText(label).applyStyle(labelStyle);
+        sh.cell(4, col).setText(value).applyStyle(valueStyle);
+        sh.setColumnWidth(col, 18);
+    }
+}

--- a/examples/RowFromArrayExample.java
+++ b/examples/RowFromArrayExample.java
@@ -1,0 +1,51 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+
+/**
+ * Beginner example showing how to write a whole row from an array in ONE call,
+ * instead of reaching for each cell individually.
+ *
+ * <p>Two patterns are demonstrated:</p>
+ * <ul>
+ *   <li>{@code row(n).setRowValues(String[])} — when every cell is a string
+ *       (headers are the classic use case)</li>
+ *   <li>{@code row(n).setValues(Object[])} — when the row mixes strings, numbers,
+ *       dates, booleans, etc.</li>
+ * </ul>
+ *
+ * <p>Both methods handle cell creation, so you don't have to loop or track columns.</p>
+ */
+public class RowFromArrayExample {
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/rowFromArray.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("Shopping");
+        sh.activate();
+
+        sh.cell(1, 1).setText("Weekly Shopping List");
+        sh.mergeCells(1, 1, 1, 4);
+        sh.row(1).applyStyle(ExcelStyle.header(), 1, 5);
+
+        // 1. Header row from a String[] — one call writes all four columns.
+        String[] headers = {"Item", "Qty", "Unit", "Aisle"};
+        sh.row(2).setRowValues(headers);
+        sh.row(2).applyStyle(ExcelStyle.header());
+
+        // 2. Data rows from Object[] — mixed types (String, int, String, String)
+        //    get routed to the right Excel cell type automatically.
+        sh.row(3).setValues(new Object[]{"Apples",  6, "pcs",  "Produce"});
+        sh.row(4).setValues(new Object[]{"Milk",    2, "L",    "Dairy"});
+        sh.row(5).setValues(new Object[]{"Bread",   1, "loaf", "Bakery"});
+        sh.row(6).setValues(new Object[]{"Coffee",  1, "kg",   "Grocery"});
+        sh.row(7).setValues(new Object[]{"Eggs",   12, "pcs",  "Dairy"});
+
+        sh.autoSizeAllColumns();
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("Rows from arrays written to ./resources/testdata/rowFromArray.xlsx");
+    }
+}

--- a/examples/TitleAndContentExample.java
+++ b/examples/TitleAndContentExample.java
@@ -1,0 +1,47 @@
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+
+/**
+ * The simplest possible styled workbook — a title and a few lines of content.
+ * No beans, no annotations, no loops. Ideal starting point for first-time users.
+ *
+ * <p>Shows just three things:</p>
+ * <ol>
+ *   <li>Merge cells to make a title band</li>
+ *   <li>Apply a built-in {@link ExcelStyle} preset ({@code header})</li>
+ *   <li>Write plain text rows below it</li>
+ * </ol>
+ */
+public class TitleAndContentExample {
+
+    public static void main(String[] args) {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/titleContent.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("Notes");
+        sh.activate();
+
+        sh.cell(1, 1).setText("Project Kickoff — 2026 Roadmap");
+        sh.mergeCells(1, 1, 1, 4);
+        sh.row(1).applyStyle(ExcelStyle.header(), 1, 5);
+
+        ExcelStyle bold = ExcelStyle.builder().bold(true).build();
+
+        sh.cell(3, 1).setText("Goals").applyStyle(bold);
+        sh.cell(4, 1).setText("• Migrate all clients to the v2 API");
+        sh.cell(5, 1).setText("• Cut average latency by 30%");
+        sh.cell(6, 1).setText("• Launch mobile SDK in Q3");
+
+        sh.cell(8, 1).setText("Owners").applyStyle(bold);
+        sh.cell(9, 1).setText("• Engineering — John Smith");
+        sh.cell(10, 1).setText("• Product — Amina Khan");
+        sh.cell(11, 1).setText("• Design — John Jones");
+
+        sh.autoSizeAllColumns();
+
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        System.out.println("Title + content written to ./resources/testdata/titleContent.xlsx");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <!-- ───────── coordinates ───────── -->
     <groupId>solutions.bismi.excel</groupId>
     <artifactId>excel</artifactId>
-    <version>1.1.12</version>
+    <version>1.2.0</version>
 
     <name>Excel</name>
     <description>Easy-to-use Excel wrapper for Apache POI</description>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <apachepoi.version>5.4.1</apachepoi.version>
-        <junit.version>5.10.0</junit.version>
-        <log4j.version>2.20.0</log4j.version>
-        <commons.lang.version>3.13.0</commons.lang.version>
-        <jacoco.version>0.8.11</jacoco.version>
-        <lombok.version>1.18.30</lombok.version>
+        <apachepoi.version>5.5.1</apachepoi.version>
+        <junit.version>5.13.4</junit.version>
+        <log4j.version>2.25.4</log4j.version>
+        <commons.lang.version>3.20.0</commons.lang.version>
+        <jacoco.version>0.8.14</jacoco.version>
+        <lombok.version>1.18.44</lombok.version>
     </properties>
 
     <!-- ───────── dependencies ───────── -->
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -168,7 +168,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -184,7 +184,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.8</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/src/main/java/solutions/bismi/excel/ExcelCell.java
+++ b/src/main/java/solutions/bismi/excel/ExcelCell.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellUtil;
 
@@ -113,110 +114,88 @@ public class ExcelCell {
         return localCell;
     }
 
-    public boolean setText(String sText) {
-
-
+    public ExcelCell setText(String sText) {
         return setText(sText, false);
-
     }
 
-    public boolean setCellValue(String sText) {
-
-
+    public ExcelCell setCellValue(String sText) {
         return setCellValue(sText, false);
-
     }
 
     /**
-     * Sets a text value in the cell.
+     * Sets a plain text value in the cell.
      *
      * @param sText           The text value to set
      * @param autoSizeColoumn Whether to auto-size the column
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setCellValue(String sText, boolean autoSizeColoumn) {
+    public ExcelCell setCellValue(String sText, boolean autoSizeColoumn) {
         try {
             this.getCell().setCellValue(sText);
             if (autoSizeColoumn) {
                 this.sheet.autoSizeColumn(col - 1);
             }
-            return true;
         } catch (Exception e) {
             log.error("Error in setting cell value: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     /**
-     * Sets a numeric value in the cell
+     * Sets a numeric value in the cell.
      *
      * @param value          The numeric value to set
      * @param autoSizeColumn Whether to auto-size the column
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setNumericValue(double value, boolean autoSizeColumn) {
+    public ExcelCell setNumericValue(double value, boolean autoSizeColumn) {
         try {
             this.getCell().setCellValue(value);
             if (autoSizeColumn) {
                 this.sheet.autoSizeColumn(col - 1);
             }
-            return true;
         } catch (Exception e) {
             log.error("Error in setting numeric value: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
-    /**
-     * Sets a numeric value in the cell
-     *
-     * @param value The numeric value to set
-     * @return true if successful, false otherwise
-     */
-    public boolean setNumericValue(double value) {
+    public ExcelCell setNumericValue(double value) {
         return setNumericValue(value, false);
     }
 
     /**
-     * Sets a date value in the cell
+     * Sets a date value in the cell.
      *
      * @param date           The date value to set
      * @param autoSizeColumn Whether to auto-size the column
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setDateValue(java.util.Date date, boolean autoSizeColumn) {
+    public ExcelCell setDateValue(java.util.Date date, boolean autoSizeColumn) {
         try {
             this.getCell().setCellValue(date);
             if (autoSizeColumn) {
                 this.sheet.autoSizeColumn(col - 1);
             }
-            return true;
         } catch (Exception e) {
             log.error("Error in setting date value: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
-    /**
-     * Sets a date value in the cell
-     *
-     * @param date The date value to set
-     * @return true if successful, false otherwise
-     */
-    public boolean setDateValue(java.util.Date date) {
+    public ExcelCell setDateValue(java.util.Date date) {
         return setDateValue(date, false);
     }
 
     /**
-     * Sets a formula in the cell
+     * Sets a formula in the cell. Leading {@code =} is stripped if present.
      *
-     * @param formula        The formula to set (without the leading '=')
+     * @param formula        The formula to set
      * @param autoSizeColumn Whether to auto-size the column
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setFormula(String formula, boolean autoSizeColumn) {
+    public ExcelCell setFormula(String formula, boolean autoSizeColumn) {
         try {
-            // Remove leading equals sign if present
             if (formula != null && formula.startsWith("=")) {
                 formula = formula.substring(1);
             }
@@ -224,47 +203,35 @@ public class ExcelCell {
             if (autoSizeColumn) {
                 this.sheet.autoSizeColumn(col - 1);
             }
-            return true;
         } catch (Exception e) {
             log.error("Error in setting formula: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
-    /**
-     * Sets a formula in the cell
-     *
-     * @param formula The formula to set (without the leading '=')
-     * @return true if successful, false otherwise
-     */
-    public boolean setFormula(String formula) {
+    public ExcelCell setFormula(String formula) {
         return setFormula(formula, false);
     }
 
     /**
-     * Sets a text value in the cell with text formatting.
+     * Sets a text value in the cell with explicit "@" text formatting.
      *
      * @param sText           The text value to set
      * @param autoSizeColoumn Whether to auto-size the column
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setText(String sText, boolean autoSizeColoumn) {
-        Cell cCell = null;
-
+    public ExcelCell setText(String sText, boolean autoSizeColoumn) {
         try {
-            cCell = this.getCell();
+            Cell cCell = this.getCell();
 
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
             newStyle.cloneStyleFrom(originalStyle);
 
-            // Set the data format to Text
             DataFormat format = workbook.createDataFormat();
-            newStyle.setDataFormat(format.getFormat("@"));  // "@" is the format code for Text
+            newStyle.setDataFormat(format.getFormat("@"));
 
-            // Use RichTextString for long text to ensure proper handling
             if (sText != null && !sText.isEmpty()) {
                 RichTextString richText = workbook.getCreationHelper().createRichTextString(sText);
                 cCell.setCellValue(richText);
@@ -277,12 +244,10 @@ public class ExcelCell {
             if (autoSizeColoumn) {
                 this.sheet.autoSizeColumn(col - 1);
             }
-
-            return true;
         } catch (Exception e) {
             log.error("Error in setting text value: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     private void setHexColor(String hexColor, Font newFont) {
@@ -397,39 +362,36 @@ public class ExcelCell {
      * Sets the background fill color for the cell.
      *
      * @param fillColor The color name to set for the cell background
+     * @return this cell for chaining
      */
-    public void setFillColor(String fillColor) {
+    public ExcelCell setFillColor(String fillColor) {
         try {
             Cell cCell = this.getCell();
 
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
             newStyle.cloneStyleFrom(originalStyle);
 
-            // Set the fill pattern and color
             newStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
             newStyle.setFillForegroundColor(Common.getColorCode(fillColor));
 
-            // Apply the new style to the cell
             cCell.setCellStyle(newStyle);
         } catch (Exception e) {
             log.error("Error in setting fill color: {}", e.getMessage());
         }
+        return this;
     }
 
     /**
-     * Sets the horizontal alignment of the cell content
+     * Sets the horizontal alignment of the cell content.
      *
-     * @param alignment The alignment to set (LEFT, CENTER, RIGHT, etc.)
-     * @return true if successful, false otherwise
+     * @param alignment LEFT / CENTER / RIGHT / JUSTIFY / FILL / GENERAL
+     * @return this cell for chaining
      */
-    public boolean setHorizontalAlignment(String alignment) {
+    public ExcelCell setHorizontalAlignment(String alignment) {
         try {
             Cell cCell = this.getCell();
-
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
@@ -437,48 +399,30 @@ public class ExcelCell {
 
             HorizontalAlignment hAlign;
             switch (alignment.toUpperCase()) {
-                case "LEFT":
-                    hAlign = HorizontalAlignment.LEFT;
-                    break;
-                case "CENTER":
-                    hAlign = HorizontalAlignment.CENTER;
-                    break;
-                case "RIGHT":
-                    hAlign = HorizontalAlignment.RIGHT;
-                    break;
-                case "JUSTIFY":
-                    hAlign = HorizontalAlignment.JUSTIFY;
-                    break;
-                case "FILL":
-                    hAlign = HorizontalAlignment.FILL;
-                    break;
-                default:
-                    hAlign = HorizontalAlignment.GENERAL;
+                case "LEFT":    hAlign = HorizontalAlignment.LEFT;    break;
+                case "CENTER":  hAlign = HorizontalAlignment.CENTER;  break;
+                case "RIGHT":   hAlign = HorizontalAlignment.RIGHT;   break;
+                case "JUSTIFY": hAlign = HorizontalAlignment.JUSTIFY; break;
+                case "FILL":    hAlign = HorizontalAlignment.FILL;    break;
+                default:        hAlign = HorizontalAlignment.GENERAL;
             }
-
-            // Set the horizontal alignment
             newStyle.setAlignment(hAlign);
-
-            // Apply the new style to the cell
             cCell.setCellStyle(newStyle);
-            return true;
         } catch (Exception e) {
             log.error("Error in setting horizontal alignment: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     /**
-     * Sets the vertical alignment of the cell content
+     * Sets the vertical alignment of the cell content.
      *
-     * @param alignment The alignment to set (TOP, CENTER, BOTTOM, etc.)
-     * @return true if successful, false otherwise
+     * @param alignment TOP / CENTER / BOTTOM / JUSTIFY / DISTRIBUTED
+     * @return this cell for chaining
      */
-    public boolean setVerticalAlignment(String alignment) {
+    public ExcelCell setVerticalAlignment(String alignment) {
         try {
             Cell cCell = this.getCell();
-
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
@@ -486,75 +430,51 @@ public class ExcelCell {
 
             VerticalAlignment vAlign;
             switch (alignment.toUpperCase()) {
-                case "TOP":
-                    vAlign = VerticalAlignment.TOP;
-                    break;
-                case "CENTER":
-                    vAlign = VerticalAlignment.CENTER;
-                    break;
-                case "BOTTOM":
-                    vAlign = VerticalAlignment.BOTTOM;
-                    break;
-                case "JUSTIFY":
-                    vAlign = VerticalAlignment.JUSTIFY;
-                    break;
-                case "DISTRIBUTED":
-                    vAlign = VerticalAlignment.DISTRIBUTED;
-                    break;
-                default:
-                    vAlign = VerticalAlignment.CENTER;
+                case "TOP":         vAlign = VerticalAlignment.TOP;         break;
+                case "CENTER":      vAlign = VerticalAlignment.CENTER;      break;
+                case "BOTTOM":      vAlign = VerticalAlignment.BOTTOM;      break;
+                case "JUSTIFY":     vAlign = VerticalAlignment.JUSTIFY;     break;
+                case "DISTRIBUTED": vAlign = VerticalAlignment.DISTRIBUTED; break;
+                default:            vAlign = VerticalAlignment.CENTER;
             }
-
-            // Set the vertical alignment
             newStyle.setVerticalAlignment(vAlign);
-
-            // Apply the new style to the cell
             cCell.setCellStyle(newStyle);
-            return true;
         } catch (Exception e) {
             log.error("Error in setting vertical alignment: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     /**
-     * Sets the number format for the cell
+     * Sets the number format for the cell.
      *
-     * @param formatPattern The format pattern to use (e.g., "#,##0.00", "dd/mm/yyyy")
-     * @return true if successful, false otherwise
+     * @param formatPattern e.g. "#,##0.00", "dd/mm/yyyy", "$#,##0.00"
+     * @return this cell for chaining
      */
-    public boolean setNumberFormat(String formatPattern) {
+    public ExcelCell setNumberFormat(String formatPattern) {
         try {
             Cell cCell = this.getCell();
-
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
             newStyle.cloneStyleFrom(originalStyle);
 
-            // Set the number format
             DataFormat format = workbook.createDataFormat();
             newStyle.setDataFormat(format.getFormat(formatPattern));
 
-            // Apply the new style to the cell
             cCell.setCellStyle(newStyle);
-            return true;
         } catch (Exception e) {
             log.error("Error in setting number format: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     /**
-     * Sets the font style (bold, italic, etc.)
+     * Sets the font style (bold, italic, underline).
      *
-     * @param bold      true to make the font bold
-     * @param italic    true to make the font italic
-     * @param underline true to underline the text
-     * @return true if successful, false otherwise
+     * @return this cell for chaining
      */
-    public boolean setFontStyle(boolean bold, boolean italic, boolean underline) {
+    public ExcelCell setFontStyle(boolean bold, boolean italic, boolean underline) {
         try {
             Cell cCell = this.getCell();
             Font font = wb.createFont();
@@ -564,29 +484,26 @@ public class ExcelCell {
                 font.setUnderline(org.apache.poi.ss.usermodel.FontUnderline.SINGLE.getByteValue());
             }
             CellUtil.setFont(cCell, font);
-            return true;
         } catch (Exception e) {
             log.error("Error in setting font style: {}", e.getMessage());
-            return false;
         }
+        return this;
     }
 
     /**
-     * Sets a full border around the cell with the specified color.
+     * Adds a medium-weight border (all four sides) around the cell.
      *
-     * @param borderColor The color name to set for the border
+     * @param borderColor colour of the border (named or hex for XLSX)
+     * @return this cell for chaining
      */
-    public void setFullBorder(String borderColor) {
+    public ExcelCell setFullBorder(String borderColor) {
         try {
             Cell cCell = this.getCell();
-
-            // Get the current cell style
             Workbook workbook = cCell.getSheet().getWorkbook();
             CellStyle originalStyle = cCell.getCellStyle();
             CellStyle newStyle = workbook.createCellStyle();
             newStyle.cloneStyleFrom(originalStyle);
 
-            // Set border styles directly
             short colorCode = Common.getColorCode(borderColor);
 
             newStyle.setBorderLeft(BorderStyle.MEDIUM);
@@ -599,11 +516,11 @@ public class ExcelCell {
             newStyle.setTopBorderColor(colorCode);
             newStyle.setBottomBorderColor(colorCode);
 
-            // Apply the new style to the cell
             cCell.setCellStyle(newStyle);
         } catch (Exception e) {
             log.error("Error in setting border: {}", e.getMessage());
         }
+        return this;
     }
 
 
@@ -614,6 +531,119 @@ public class ExcelCell {
      */
     public String getValue() {
         return getTextValue();
+    }
+
+    /**
+     * Polymorphic value setter — dispatches to the correct typed setter based on runtime type.
+     * Accepts {@link Number}, {@link Boolean}, {@link java.util.Date}, {@link java.time.LocalDate},
+     * {@link java.time.LocalDateTime}, {@link CharSequence}, or {@code null}. Anything else
+     * is written via {@code toString()}.
+     *
+     * @param value the value to write
+     * @return this cell for chaining
+     */
+    public ExcelCell setValue(Object value) {
+        try {
+            Cell c = this.getCell();
+            if (value == null) {
+                c.setBlank();
+            } else if (value instanceof Number) {
+                c.setCellValue(((Number) value).doubleValue());
+            } else if (value instanceof Boolean) {
+                c.setCellValue((Boolean) value);
+            } else if (value instanceof java.util.Date) {
+                c.setCellValue((java.util.Date) value);
+            } else if (value instanceof java.time.LocalDate) {
+                c.setCellValue((java.time.LocalDate) value);
+            } else if (value instanceof java.time.LocalDateTime) {
+                c.setCellValue((java.time.LocalDateTime) value);
+            } else if (value instanceof CharSequence) {
+                c.setCellValue(value.toString());
+            } else {
+                c.setCellValue(value.toString());
+            }
+        } catch (Exception e) {
+            log.error("Error in setValue: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Applies a reusable {@link ExcelStyle} to this cell.
+     *
+     * @param style the style to apply (no-op if null)
+     * @return this cell for chaining
+     */
+    public ExcelCell applyStyle(ExcelStyle style) {
+        if (style != null) {
+            style.applyTo(this);
+        }
+        return this;
+    }
+
+    /**
+     * Attaches a clickable hyperlink to this cell (URL, email, or file path).
+     *
+     * @param url       target URL (e.g. {@code https://example.com} or {@code mailto:a@b.com})
+     * @param displayText text shown in the cell (if null, the URL is used)
+     * @return this cell for chaining
+     */
+    public ExcelCell setHyperlink(String url, String displayText) {
+        try {
+            Cell c = this.getCell();
+            Workbook workbook = c.getSheet().getWorkbook();
+            CreationHelper helper = workbook.getCreationHelper();
+            HyperlinkType type = HyperlinkType.URL;
+            if (url != null && url.toLowerCase().startsWith("mailto:")) {
+                type = HyperlinkType.EMAIL;
+            } else if (url != null && (url.startsWith("file:") || url.matches("^[A-Za-z]:\\\\.*") || url.startsWith("/"))) {
+                type = HyperlinkType.FILE;
+            }
+            Hyperlink link = helper.createHyperlink(type);
+            link.setAddress(url);
+            c.setHyperlink(link);
+            c.setCellValue(displayText != null ? displayText : url);
+
+            Font blue = workbook.createFont();
+            blue.setColor(IndexedColors.BLUE.getIndex());
+            blue.setUnderline(Font.U_SINGLE);
+            CellStyle linkStyle = workbook.createCellStyle();
+            linkStyle.cloneStyleFrom(c.getCellStyle());
+            linkStyle.setFont(blue);
+            c.setCellStyle(linkStyle);
+        } catch (Exception e) {
+            log.error("Error setting hyperlink: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Attaches a note / comment to this cell (appears on hover in Excel).
+     *
+     * @param text   comment body
+     * @param author author label (null falls back to empty)
+     * @return this cell for chaining
+     */
+    public ExcelCell setComment(String text, String author) {
+        try {
+            Cell c = this.getCell();
+            Sheet s = c.getSheet();
+            Workbook workbook = s.getWorkbook();
+            Drawing<?> drawing = s.createDrawingPatriarch();
+            CreationHelper helper = workbook.getCreationHelper();
+            ClientAnchor anchor = helper.createClientAnchor();
+            anchor.setCol1(c.getColumnIndex());
+            anchor.setCol2(c.getColumnIndex() + 3);
+            anchor.setRow1(c.getRowIndex());
+            anchor.setRow2(c.getRowIndex() + 3);
+            Comment comment = drawing.createCellComment(anchor);
+            comment.setString(helper.createRichTextString(text != null ? text : ""));
+            comment.setAuthor(author != null ? author : "");
+            c.setCellComment(comment);
+        } catch (Exception e) {
+            log.error("Error setting cell comment: {}", e.getMessage());
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/solutions/bismi/excel/ExcelCell.java
+++ b/src/main/java/solutions/bismi/excel/ExcelCell.java
@@ -360,8 +360,12 @@ public class ExcelCell {
 
     /**
      * Sets the background fill color for the cell.
+     * <p>
+     * Accepts named colours (see {@link NamedColor}) or hex codes ({@code "#RRGGBB"}).
+     * Hex is rendered exactly on {@code .xlsx} workbooks; on {@code .xls} it falls back
+     * to the closest indexed colour.
      *
-     * @param fillColor The color name to set for the cell background
+     * @param fillColor named color or hex code
      * @return this cell for chaining
      */
     public ExcelCell setFillColor(String fillColor) {
@@ -374,13 +378,50 @@ public class ExcelCell {
             newStyle.cloneStyleFrom(originalStyle);
 
             newStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
-            newStyle.setFillForegroundColor(Common.getColorCode(fillColor));
+
+            if (fillColor != null && fillColor.startsWith("#") && fillColor.length() >= 7) {
+                String hex = fillColor.substring(1);
+                if (workbook instanceof org.apache.poi.xssf.usermodel.XSSFWorkbook) {
+                    setXSSFHexFillColor(hex, newStyle);
+                } else {
+                    setHSSFHexFillColor(hex, newStyle);
+                }
+            } else {
+                newStyle.setFillForegroundColor(Common.getColorCode(fillColor));
+            }
 
             cCell.setCellStyle(newStyle);
         } catch (Exception e) {
             log.error("Error in setting fill color: {}", e.getMessage());
         }
         return this;
+    }
+
+    private void setXSSFHexFillColor(String hex, CellStyle style) {
+        try {
+            byte[] rgb = new byte[] {
+                (byte) Integer.parseInt(hex.substring(0, 2), 16),
+                (byte) Integer.parseInt(hex.substring(2, 4), 16),
+                (byte) Integer.parseInt(hex.substring(4, 6), 16)
+            };
+            org.apache.poi.xssf.usermodel.XSSFCellStyle xs = (org.apache.poi.xssf.usermodel.XSSFCellStyle) style;
+            xs.setFillForegroundColor(new org.apache.poi.xssf.usermodel.XSSFColor(rgb, null));
+        } catch (Exception e) {
+            log.error("Error parsing hex fill color: {}", e.getMessage());
+            style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        }
+    }
+
+    private void setHSSFHexFillColor(String hex, CellStyle style) {
+        try {
+            int r = Integer.parseInt(hex.substring(0, 2), 16);
+            int g = Integer.parseInt(hex.substring(2, 4), 16);
+            int b = Integer.parseInt(hex.substring(4, 6), 16);
+            style.setFillForegroundColor(getClosestIndexedColor(r, g, b));
+        } catch (Exception e) {
+            log.error("Error parsing hex fill color for HSSF: {}", e.getMessage());
+            style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        }
     }
 
     /**

--- a/src/main/java/solutions/bismi/excel/ExcelColumn.java
+++ b/src/main/java/solutions/bismi/excel/ExcelColumn.java
@@ -1,0 +1,38 @@
+package solutions.bismi.excel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field for Excel serialization. Use with {@code writeBeans} / {@code readAsBeans}
+ * on {@link ExcelWorkSheet}.
+ *
+ * <pre>
+ * public class Product {
+ *     &#064;ExcelColumn(name = "Item", order = 1)          String name;
+ *     &#064;ExcelColumn(name = "Price", order = 2, format = "$#,##0.00") double price;
+ *     &#064;ExcelColumn(name = "Launched", order = 3, format = "dd-MMM-yyyy") java.util.Date launchedOn;
+ * }
+ * </pre>
+ *
+ * <p>Unannotated fields are ignored. If {@code name} is empty, the field name is used.
+ * If {@code order} is unset, fields appear in declaration order after ordered ones.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExcelColumn {
+
+    /** Header label written to row 1. Defaults to the field name. */
+    String name() default "";
+
+    /** Column position (1-based). Lower values appear first. Defaults to declaration order. */
+    int order() default Integer.MAX_VALUE;
+
+    /**
+     * Excel number/date format pattern applied to this column's data rows.
+     * Examples: {@code "#,##0.00"}, {@code "0.00%"}, {@code "dd-MMM-yyyy"}, {@code "@"}.
+     */
+    String format() default "";
+}

--- a/src/main/java/solutions/bismi/excel/ExcelRow.java
+++ b/src/main/java/solutions/bismi/excel/ExcelRow.java
@@ -295,6 +295,56 @@ public class ExcelRow {
     }
 
     /**
+     * Sets values of mixed types in this row (Number, Date, Boolean, String, null).
+     * Prefer this over {@link #setRowValues(String[])} when your data is not all strings.
+     *
+     * @param values values to write, starting at column 1
+     */
+    public void setValues(Object[] values) {
+        setValues(values, 1);
+    }
+
+    /**
+     * Sets values of mixed types starting at the specified 1-based column.
+     */
+    public void setValues(Object[] values, int startCol) {
+        if (values == null || values.length == 0) return;
+        for (int i = 0; i < values.length; i++) {
+            ExcelCell c = new ExcelCell(sheet, wb, rowNumber, startCol + i, inputStream, outputStream, sCompleteFileName);
+            c.setValue(values[i]);
+        }
+    }
+
+    /**
+     * Applies a reusable {@link ExcelStyle} to every populated cell in this row.
+     * If the row is empty, applies to column 1 only.
+     */
+    public ExcelRow applyStyle(ExcelStyle style) {
+        if (style == null) return this;
+        Row cRow = getOrCreateRow();
+        int endCol = cRow == null ? 1 : cRow.getLastCellNum();
+        if (endCol <= 0) endCol = 1;
+        applyStyle(style, 1, endCol + 1);
+        return this;
+    }
+
+    /**
+     * Applies a reusable {@link ExcelStyle} to a range of cells in this row.
+     *
+     * @param style    style to apply
+     * @param startCol 1-based start column (inclusive)
+     * @param endCol   end column (exclusive)
+     */
+    public ExcelRow applyStyle(ExcelStyle style, int startCol, int endCol) {
+        if (style == null) return this;
+        for (int c = startCol; c < endCol; c++) {
+            ExcelCell cell = new ExcelCell(sheet, wb, rowNumber, c, inputStream, outputStream, sCompleteFileName);
+            style.applyTo(cell);
+        }
+        return this;
+    }
+
+    /**
      * Checks if a row is empty or contains only blank cells.
      * Delegates to Common utility method.
      *

--- a/src/main/java/solutions/bismi/excel/ExcelStyle.java
+++ b/src/main/java/solutions/bismi/excel/ExcelStyle.java
@@ -101,10 +101,10 @@ public final class ExcelStyle {
     /*  Ready-made presets                                                 */
     /* ------------------------------------------------------------------ */
 
-    /** Dark header with white bold centered text and black border — typical report header. */
+    /** Blue header with white bold centred text and black border — typical report header. */
     public static ExcelStyle header() {
         return builder()
-                .fillColor("grey_50_percent")
+                .fillColor("#2d6cdf")
                 .fontColor("white")
                 .bold(true)
                 .horizontalAlignment("CENTER")
@@ -112,9 +112,20 @@ public final class ExcelStyle {
                 .build();
     }
 
-    /** Light-grey alternating row fill for zebra-striped tables. */
+    /** Dark-grey variant of {@link #header()} — typical for invoices and formal documents. */
+    public static ExcelStyle greyHeader() {
+        return builder()
+                .fillColor("#636363")
+                .fontColor("white")
+                .bold(true)
+                .horizontalAlignment("CENTER")
+                .fullBorder("black")
+                .build();
+    }
+
+    /** Very light grey alternating row fill for zebra-striped tables. */
     public static ExcelStyle zebraStripe() {
-        return builder().fillColor("grey_25_percent").build();
+        return builder().fillColor("#f3f6f9").build();
     }
 
     /** Currency preset — right-aligned, {@code $#,##0.00}. */

--- a/src/main/java/solutions/bismi/excel/ExcelStyle.java
+++ b/src/main/java/solutions/bismi/excel/ExcelStyle.java
@@ -1,0 +1,134 @@
+package solutions.bismi.excel;
+
+/**
+ * Reusable, immutable style definition. Build once, apply to many cells — avoids
+ * the repetition of calling {@code setFontColor / setFillColor / setFullBorder}
+ * on every cell and sidesteps Apache POI's {@code CellStyle} quota (64,000 per workbook)
+ * by letting callers reuse the same style object.
+ *
+ * <pre>
+ * ExcelStyle header = ExcelStyle.builder()
+ *     .fillColor("grey_50_percent")
+ *     .fontColor("white")
+ *     .bold(true)
+ *     .horizontalAlignment("CENTER")
+ *     .fullBorder("black")
+ *     .build();
+ *
+ * sheet.row(1).applyStyle(header);
+ * </pre>
+ */
+public final class ExcelStyle {
+
+    private final String fontColor;
+    private final String fillColor;
+    private final String borderColor;
+    private final String horizontalAlignment;
+    private final String verticalAlignment;
+    private final String numberFormat;
+    private final boolean bold;
+    private final boolean italic;
+    private final boolean underline;
+
+    private ExcelStyle(Builder b) {
+        this.fontColor = b.fontColor;
+        this.fillColor = b.fillColor;
+        this.borderColor = b.borderColor;
+        this.horizontalAlignment = b.horizontalAlignment;
+        this.verticalAlignment = b.verticalAlignment;
+        this.numberFormat = b.numberFormat;
+        this.bold = b.bold;
+        this.italic = b.italic;
+        this.underline = b.underline;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getFontColor() { return fontColor; }
+    public String getFillColor() { return fillColor; }
+    public String getBorderColor() { return borderColor; }
+    public String getHorizontalAlignment() { return horizontalAlignment; }
+    public String getVerticalAlignment() { return verticalAlignment; }
+    public String getNumberFormat() { return numberFormat; }
+    public boolean isBold() { return bold; }
+    public boolean isItalic() { return italic; }
+    public boolean isUnderline() { return underline; }
+
+    /**
+     * Applies this style to the given cell. Font-style flags (bold/italic/underline)
+     * are always applied; other properties are applied only when set.
+     */
+    public void applyTo(ExcelCell cell) {
+        if (cell == null) return;
+        if (bold || italic || underline) {
+            cell.setFontStyle(bold, italic, underline);
+        }
+        if (fontColor != null)            cell.setFontColor(fontColor);
+        if (fillColor != null)            cell.setFillColor(fillColor);
+        if (borderColor != null)          cell.setFullBorder(borderColor);
+        if (horizontalAlignment != null)  cell.setHorizontalAlignment(horizontalAlignment);
+        if (verticalAlignment != null)    cell.setVerticalAlignment(verticalAlignment);
+        if (numberFormat != null)         cell.setNumberFormat(numberFormat);
+    }
+
+    public static final class Builder {
+        private String fontColor;
+        private String fillColor;
+        private String borderColor;
+        private String horizontalAlignment;
+        private String verticalAlignment;
+        private String numberFormat;
+        private boolean bold;
+        private boolean italic;
+        private boolean underline;
+
+        public Builder fontColor(String c)            { this.fontColor = c;            return this; }
+        public Builder fillColor(String c)            { this.fillColor = c;            return this; }
+        public Builder fullBorder(String c)           { this.borderColor = c;          return this; }
+        public Builder horizontalAlignment(String a)  { this.horizontalAlignment = a;  return this; }
+        public Builder verticalAlignment(String a)    { this.verticalAlignment = a;    return this; }
+        public Builder numberFormat(String f)         { this.numberFormat = f;         return this; }
+        public Builder bold(boolean v)                { this.bold = v;                 return this; }
+        public Builder italic(boolean v)              { this.italic = v;               return this; }
+        public Builder underline(boolean v)           { this.underline = v;            return this; }
+
+        public ExcelStyle build() { return new ExcelStyle(this); }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Ready-made presets                                                 */
+    /* ------------------------------------------------------------------ */
+
+    /** Dark header with white bold centered text and black border — typical report header. */
+    public static ExcelStyle header() {
+        return builder()
+                .fillColor("grey_50_percent")
+                .fontColor("white")
+                .bold(true)
+                .horizontalAlignment("CENTER")
+                .fullBorder("black")
+                .build();
+    }
+
+    /** Light-grey alternating row fill for zebra-striped tables. */
+    public static ExcelStyle zebraStripe() {
+        return builder().fillColor("grey_25_percent").build();
+    }
+
+    /** Currency preset — right-aligned, {@code $#,##0.00}. */
+    public static ExcelStyle currency() {
+        return builder().numberFormat("$#,##0.00").horizontalAlignment("RIGHT").build();
+    }
+
+    /** Percentage preset — right-aligned, {@code 0.00%}. */
+    public static ExcelStyle percent() {
+        return builder().numberFormat("0.00%").horizontalAlignment("RIGHT").build();
+    }
+
+    /** Plain date preset — {@code dd-MMM-yyyy}. */
+    public static ExcelStyle date() {
+        return builder().numberFormat("dd-MMM-yyyy").build();
+    }
+}

--- a/src/main/java/solutions/bismi/excel/ExcelWorkSheet.java
+++ b/src/main/java/solutions/bismi/excel/ExcelWorkSheet.java
@@ -2,11 +2,22 @@ package solutions.bismi.excel;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellRangeAddress;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -306,6 +317,327 @@ public class ExcelWorkSheet {
             log.error("Error unmerging cells: {}", e.getMessage());
             return false;
         }
+    }
+
+    /* ===================================================================== */
+    /*  Layout conveniences                                                  */
+    /* ===================================================================== */
+
+    /**
+     * Freezes rows above and columns to the left of the given cell so they stay
+     * visible while scrolling. Pass {@code (2, 1)} to freeze the header row.
+     *
+     * @param row 1-based row — rows above (exclusive) stay frozen
+     * @param col 1-based column — columns to the left (exclusive) stay frozen
+     * @return this sheet for chaining
+     */
+    public ExcelWorkSheet freezePane(int row, int col) {
+        try {
+            sheet.createFreezePane(Math.max(0, col - 1), Math.max(0, row - 1));
+            saveWorkBook();
+        } catch (Exception e) {
+            log.error("Error setting freeze pane: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Enables Excel's dropdown filters on a header row.
+     *
+     * @param headerRow 1-based header row
+     * @param firstCol  1-based first column of the filter range
+     * @param lastCol   1-based last column of the filter range (inclusive)
+     * @return this sheet for chaining
+     */
+    public ExcelWorkSheet enableAutoFilter(int headerRow, int firstCol, int lastCol) {
+        try {
+            sheet.setAutoFilter(new CellRangeAddress(headerRow - 1, headerRow - 1, firstCol - 1, lastCol - 1));
+            saveWorkBook();
+        } catch (Exception e) {
+            log.error("Error enabling auto-filter: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Sets the width of a column in characters (roughly the Excel units × 256).
+     *
+     * @param col   1-based column
+     * @param width width in character units (e.g. 20)
+     */
+    public ExcelWorkSheet setColumnWidth(int col, int width) {
+        try {
+            sheet.setColumnWidth(col - 1, width * 256);
+        } catch (Exception e) {
+            log.error("Error setting column width: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Auto-sizes every populated column to fit its widest cell content.
+     * Safe to call after all data is written.
+     */
+    public ExcelWorkSheet autoSizeAllColumns() {
+        try {
+            int lastCol = getColNumber();
+            for (int c = 0; c < lastCol; c++) {
+                sheet.autoSizeColumn(c);
+            }
+        } catch (Exception e) {
+            log.error("Error auto-sizing columns: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Protects the sheet with a password. Password may be null to enable protection
+     * without one.
+     */
+    public ExcelWorkSheet protect(String password) {
+        try {
+            sheet.protectSheet(password);
+            saveWorkBook();
+        } catch (Exception e) {
+            log.error("Error protecting sheet: {}", e.getMessage());
+        }
+        return this;
+    }
+
+    /* ===================================================================== */
+    /*  Collection framework — write                                         */
+    /* ===================================================================== */
+
+    /**
+     * Writes a list of maps as a table. Keys of the first map become the headers
+     * (in iteration order — use {@link LinkedHashMap} to preserve column order).
+     * Subsequent rows pull values by key.
+     *
+     * <pre>
+     * List&lt;Map&lt;String,Object&gt;&gt; rows = List.of(
+     *     Map.of("Item","Apple", "Qty",10, "Price",1.20),
+     *     Map.of("Item","Pear",  "Qty",8,  "Price",1.80));
+     * sheet.writeMaps(rows);
+     * </pre>
+     *
+     * @param rows the data rows (null/empty is a no-op)
+     * @return this sheet for chaining
+     */
+    public ExcelWorkSheet writeMaps(List<? extends Map<String, ?>> rows) {
+        if (rows == null || rows.isEmpty()) return this;
+        List<String> headers = new ArrayList<>(rows.get(0).keySet());
+        String[] headerArr = headers.toArray(new String[0]);
+        row(1).setRowValues(headerArr);
+        for (int i = 0; i < rows.size(); i++) {
+            Object[] values = new Object[headers.size()];
+            Map<String, ?> src = rows.get(i);
+            for (int c = 0; c < headers.size(); c++) {
+                values[c] = src.get(headers.get(c));
+            }
+            row(i + 2).setValues(values);
+        }
+        saveWorkBook();
+        return this;
+    }
+
+    /**
+     * Writes a list of beans annotated with {@link ExcelColumn}. Only annotated fields
+     * are exported; ordering comes from {@code order()}, then declaration order. Field
+     * {@code format()} is applied to the column's data rows.
+     *
+     * @param beans list of beans (null/empty is a no-op)
+     * @param <T>   bean type
+     * @return this sheet for chaining
+     */
+    public <T> ExcelWorkSheet writeBeans(List<T> beans) {
+        if (beans == null || beans.isEmpty()) return this;
+        Class<?> clazz = beans.get(0).getClass();
+        List<Field> fields = getExcelFields(clazz);
+        if (fields.isEmpty()) {
+            log.warn("Class {} has no @ExcelColumn fields; nothing written", clazz.getSimpleName());
+            return this;
+        }
+        String[] headers = new String[fields.size()];
+        for (int i = 0; i < fields.size(); i++) {
+            ExcelColumn ann = fields.get(i).getAnnotation(ExcelColumn.class);
+            headers[i] = ann.name().isEmpty() ? fields.get(i).getName() : ann.name();
+        }
+        row(1).setRowValues(headers);
+        for (int r = 0; r < beans.size(); r++) {
+            Object[] values = new Object[fields.size()];
+            T bean = beans.get(r);
+            for (int c = 0; c < fields.size(); c++) {
+                try {
+                    fields.get(c).setAccessible(true);
+                    values[c] = fields.get(c).get(bean);
+                } catch (Exception e) {
+                    log.error("Error reading field {}: {}", fields.get(c).getName(), e.getMessage());
+                }
+            }
+            row(r + 2).setValues(values);
+        }
+        for (int c = 0; c < fields.size(); c++) {
+            String fmt = fields.get(c).getAnnotation(ExcelColumn.class).format();
+            if (!fmt.isEmpty()) {
+                for (int r = 2; r <= beans.size() + 1; r++) {
+                    cell(r, c + 1).setNumberFormat(fmt);
+                }
+            }
+        }
+        saveWorkBook();
+        return this;
+    }
+
+    /* ===================================================================== */
+    /*  Collection framework — read                                          */
+    /* ===================================================================== */
+
+    /**
+     * Reads the sheet into a list of maps, using row 1 as headers.
+     *
+     * @return a list of {@link LinkedHashMap}s — empty if sheet is empty
+     */
+    public List<Map<String, String>> readAsMaps() {
+        List<Map<String, String>> result = new ArrayList<>();
+        try {
+            int lastRow = sheet.getLastRowNum();
+            Row header = sheet.getRow(0);
+            if (header == null) return result;
+            int lastCol = header.getLastCellNum();
+            String[] headers = new String[lastCol];
+            for (int c = 0; c < lastCol; c++) {
+                Cell cell = header.getCell(c);
+                headers[c] = cell == null ? "" : cell.toString();
+            }
+            for (int r = 1; r <= lastRow; r++) {
+                Row row = sheet.getRow(r);
+                if (row == null) continue;
+                Map<String, String> map = new LinkedHashMap<>();
+                for (int c = 0; c < lastCol; c++) {
+                    Cell cell = row.getCell(c);
+                    map.put(headers[c], stringifyCell(cell));
+                }
+                result.add(map);
+            }
+        } catch (Exception e) {
+            log.error("Error reading sheet as maps: {}", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * Reads the sheet into a list of beans using {@link ExcelColumn} annotations to map
+     * columns to fields. Requires a public no-arg constructor on {@code T}.
+     *
+     * @param clazz bean class
+     * @param <T>   bean type
+     * @return list of populated beans
+     */
+    public <T> List<T> readAsBeans(Class<T> clazz) {
+        List<T> result = new ArrayList<>();
+        List<Field> fields = getExcelFields(clazz);
+        if (fields.isEmpty()) return result;
+        Map<String, Field> byHeader = new LinkedHashMap<>();
+        for (Field f : fields) {
+            ExcelColumn ann = f.getAnnotation(ExcelColumn.class);
+            byHeader.put(ann.name().isEmpty() ? f.getName() : ann.name(), f);
+        }
+        List<Map<String, String>> rows = readAsMaps();
+        for (Map<String, String> rowMap : rows) {
+            T bean;
+            try {
+                bean = clazz.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                log.error("Cannot instantiate {} (needs a no-arg constructor): {}", clazz.getName(), e.getMessage());
+                return result;
+            }
+            for (Map.Entry<String, Field> entry : byHeader.entrySet()) {
+                String raw = rowMap.get(entry.getKey());
+                if (raw == null) continue;
+                Field f = entry.getValue();
+                try {
+                    f.setAccessible(true);
+                    Object coerced = coerce(raw, f.getType());
+                    if (coerced != null) {
+                        f.set(bean, coerced);
+                    }
+                } catch (Exception e) {
+                    log.error("Cannot set field {} from value '{}': {}", f.getName(), raw, e.getMessage());
+                }
+            }
+            result.add(bean);
+        }
+        return result;
+    }
+
+    /* ===================================================================== */
+    /*  Internal helpers                                                     */
+    /* ===================================================================== */
+
+    private static List<Field> getExcelFields(Class<?> clazz) {
+        List<Field> result = new ArrayList<>();
+        for (Class<?> c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.isAnnotationPresent(ExcelColumn.class)) {
+                    result.add(f);
+                }
+            }
+        }
+        result.sort(Comparator.comparingInt(f -> f.getAnnotation(ExcelColumn.class).order()));
+        return result;
+    }
+
+    private static String stringifyCell(Cell cell) {
+        if (cell == null) return "";
+        switch (cell.getCellType()) {
+            case STRING:  return cell.getStringCellValue();
+            case BOOLEAN: return String.valueOf(cell.getBooleanCellValue());
+            case FORMULA: return cell.getCellFormula();
+            case BLANK:   return "";
+            case NUMERIC:
+                if (DateUtil.isCellDateFormatted(cell)) {
+                    // ISO-8601 so readAsBeans can parse back into LocalDate/LocalDateTime/Date
+                    java.util.Date d = cell.getDateCellValue();
+                    java.time.LocalDateTime ldt = d.toInstant()
+                            .atZone(java.time.ZoneId.systemDefault()).toLocalDateTime();
+                    if (ldt.getHour() == 0 && ldt.getMinute() == 0 && ldt.getSecond() == 0) {
+                        return ldt.toLocalDate().toString();   // yyyy-MM-dd
+                    }
+                    return ldt.toString();                       // yyyy-MM-ddTHH:mm:ss
+                }
+                double n = cell.getNumericCellValue();
+                if (n == Math.floor(n) && !Double.isInfinite(n)) {
+                    return String.valueOf((long) n);
+                }
+                return String.valueOf(n);
+            default: return cell.toString();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Object coerce(String raw, Class<?> target) {
+        try {
+            if (target == String.class)                            return raw;
+            if (raw.isEmpty())                                     return null;
+            String t = raw.trim();
+            if (target == int.class     || target == Integer.class) return Integer.parseInt(t);
+            if (target == long.class    || target == Long.class)    return Long.parseLong(t);
+            if (target == double.class  || target == Double.class)  return Double.parseDouble(t);
+            if (target == float.class   || target == Float.class)   return Float.parseFloat(t);
+            if (target == boolean.class || target == Boolean.class) return Boolean.parseBoolean(t);
+            if (target == java.time.LocalDate.class)                return java.time.LocalDate.parse(t);
+            if (target == java.time.LocalDateTime.class)            return java.time.LocalDateTime.parse(t);
+            if (target == java.util.Date.class) {
+                java.time.LocalDateTime ldt = t.contains("T")
+                        ? java.time.LocalDateTime.parse(t)
+                        : java.time.LocalDate.parse(t).atStartOfDay();
+                return java.util.Date.from(ldt.atZone(java.time.ZoneId.systemDefault()).toInstant());
+            }
+            if (target.isEnum())                                   return Enum.valueOf((Class<Enum>) target, t);
+        } catch (Exception ignored) {
+            // fall through — return raw String
+        }
+        return raw;
     }
 
     /**

--- a/src/main/java/solutions/bismi/excel/ReportBuilder.java
+++ b/src/main/java/solutions/bismi/excel/ReportBuilder.java
@@ -1,0 +1,268 @@
+package solutions.bismi.excel;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * High-level, fluent helper for producing business-ready reports without touching
+ * {@code CellStyle}, {@code XSSFWorkbook}, or indexed rows. Typical usage:
+ *
+ * <pre>
+ * ReportBuilder.on(sheet)
+ *     .title("Q3 Sales")
+ *     .headers("Region", "Units", "Revenue")
+ *     .rows(salesData)                 // List&lt;Object[]&gt; or List&lt;Map&gt; or List&lt;Bean&gt;
+ *     .zebraStripes(true)
+ *     .freezeHeader(true)
+ *     .autoFilter(true)
+ *     .autoSize(true)
+ *     .headerStyle(ExcelStyle.header())
+ *     .render();
+ * </pre>
+ *
+ * <p>Everything above is a one-shot call — {@link #render()} writes the whole table
+ * and saves the workbook.</p>
+ */
+public final class ReportBuilder {
+
+    private final ExcelWorkSheet sheet;
+
+    private String title;
+    private ExcelStyle titleStyle;
+    private String[] headers;
+    private ExcelStyle headerStyle = ExcelStyle.header();
+    private List<Object[]> rows = new ArrayList<>();
+    private ExcelStyle rowStyle;
+    private ExcelStyle stripeStyle = ExcelStyle.zebraStripe();
+    private boolean zebra;
+    private boolean freezeHeader;
+    private boolean autoFilter;
+    private boolean autoSize = true;
+    private Map<Integer, ExcelStyle> columnStyles = new LinkedHashMap<>();
+    private Map<Integer, Integer> columnWidths = new LinkedHashMap<>();
+
+    private ReportBuilder(ExcelWorkSheet sheet) {
+        this.sheet = sheet;
+    }
+
+    /** Creates a builder bound to the given sheet. */
+    public static ReportBuilder on(ExcelWorkSheet sheet) {
+        return new ReportBuilder(sheet);
+    }
+
+    /** Adds an optional merged title row above the headers. */
+    public ReportBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    /** Custom style for the title row (defaults to bold + centered). */
+    public ReportBuilder titleStyle(ExcelStyle style) {
+        this.titleStyle = style;
+        return this;
+    }
+
+    /** Sets the column headers. */
+    public ReportBuilder headers(String... headers) {
+        this.headers = headers;
+        return this;
+    }
+
+    /** Overrides the default header style. */
+    public ReportBuilder headerStyle(ExcelStyle style) {
+        this.headerStyle = style;
+        return this;
+    }
+
+    /** Adds a single row (mixed types allowed). */
+    public ReportBuilder row(Object... values) {
+        this.rows.add(values);
+        return this;
+    }
+
+    /** Adds rows from a list of arrays. */
+    public ReportBuilder rows(List<Object[]> rows) {
+        if (rows != null) this.rows.addAll(rows);
+        return this;
+    }
+
+    /**
+     * Adds rows from a list of maps — headers are inferred from the first map's keys
+     * if not already set via {@link #headers(String...)}.
+     */
+    public ReportBuilder rowsFromMaps(List<? extends Map<String, ?>> data) {
+        if (data == null || data.isEmpty()) return this;
+        if (this.headers == null) {
+            this.headers = data.get(0).keySet().toArray(new String[0]);
+        }
+        for (Map<String, ?> m : data) {
+            Object[] values = new Object[headers.length];
+            for (int i = 0; i < headers.length; i++) {
+                values[i] = m.get(headers[i]);
+            }
+            this.rows.add(values);
+        }
+        return this;
+    }
+
+    /**
+     * Adds rows from a list of beans annotated with {@link ExcelColumn}. If headers
+     * haven't been set, they're derived from the annotations. Column formats from
+     * the annotations are applied as {@link #columnStyle(int, ExcelStyle)}.
+     */
+    public <T> ReportBuilder rowsFromBeans(List<T> beans) {
+        if (beans == null || beans.isEmpty()) return this;
+        List<Field> fields = getExcelFields(beans.get(0).getClass());
+        if (fields.isEmpty()) return this;
+        if (this.headers == null) {
+            String[] hs = new String[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                ExcelColumn ann = fields.get(i).getAnnotation(ExcelColumn.class);
+                hs[i] = ann.name().isEmpty() ? fields.get(i).getName() : ann.name();
+            }
+            this.headers = hs;
+        }
+        for (int i = 0; i < fields.size(); i++) {
+            String fmt = fields.get(i).getAnnotation(ExcelColumn.class).format();
+            if (!fmt.isEmpty()) {
+                columnStyle(i + 1, ExcelStyle.builder().numberFormat(fmt).build());
+            }
+        }
+        for (T bean : beans) {
+            Object[] values = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                try {
+                    fields.get(i).setAccessible(true);
+                    values[i] = fields.get(i).get(bean);
+                } catch (Exception ignored) { /* leave null */ }
+            }
+            this.rows.add(values);
+        }
+        return this;
+    }
+
+    /** Applies a base style to every data row. */
+    public ReportBuilder rowStyle(ExcelStyle style) {
+        this.rowStyle = style;
+        return this;
+    }
+
+    /** Overlays a different fill on every other row (readability). */
+    public ReportBuilder zebraStripes(boolean enabled) {
+        this.zebra = enabled;
+        return this;
+    }
+
+    /** Overrides the default zebra-stripe style (defaults to grey_25_percent fill). */
+    public ReportBuilder stripeStyle(ExcelStyle style) {
+        this.stripeStyle = style;
+        return this;
+    }
+
+    /**
+     * Applies a style to a specific 1-based column in every data row. Useful for
+     * number formatting (e.g. currency on column 3).
+     */
+    public ReportBuilder columnStyle(int col, ExcelStyle style) {
+        columnStyles.put(col, style);
+        return this;
+    }
+
+    /** Sets an explicit width (character units) for a 1-based column. */
+    public ReportBuilder columnWidth(int col, int width) {
+        columnWidths.put(col, width);
+        return this;
+    }
+
+    /** Freezes the header row so it stays visible while scrolling. */
+    public ReportBuilder freezeHeader(boolean enabled) {
+        this.freezeHeader = enabled;
+        return this;
+    }
+
+    /** Enables Excel's dropdown filter on the header row. */
+    public ReportBuilder autoFilter(boolean enabled) {
+        this.autoFilter = enabled;
+        return this;
+    }
+
+    /** Auto-sizes all columns after render. Defaults to {@code true}. */
+    public ReportBuilder autoSize(boolean enabled) {
+        this.autoSize = enabled;
+        return this;
+    }
+
+    /**
+     * Writes everything configured to the sheet and saves the workbook.
+     *
+     * @return the bound {@link ExcelWorkSheet} for further chaining
+     */
+    public ExcelWorkSheet render() {
+        if (headers == null || headers.length == 0) {
+            throw new IllegalStateException("ReportBuilder: headers() is required before render()");
+        }
+        int cursor = 1;
+        if (title != null && !title.isEmpty()) {
+            sheet.cell(cursor, 1).setText(title);
+            sheet.mergeCells(cursor, 1, cursor, headers.length);
+            ExcelStyle effective = titleStyle != null
+                    ? titleStyle
+                    : ExcelStyle.builder().bold(true).horizontalAlignment("CENTER").build();
+            sheet.row(cursor).applyStyle(effective, 1, headers.length + 1);
+            cursor++;
+        }
+
+        int headerRow = cursor;
+        sheet.row(headerRow).setRowValues(headers);
+        sheet.row(headerRow).applyStyle(headerStyle, 1, headers.length + 1);
+        cursor++;
+
+        for (int i = 0; i < rows.size(); i++) {
+            int r = cursor + i;
+            Object[] values = rows.get(i);
+            sheet.row(r).setValues(values);
+            if (rowStyle != null) {
+                sheet.row(r).applyStyle(rowStyle, 1, headers.length + 1);
+            }
+            if (zebra && i % 2 == 1) {
+                sheet.row(r).applyStyle(stripeStyle, 1, headers.length + 1);
+            }
+            for (Map.Entry<Integer, ExcelStyle> entry : columnStyles.entrySet()) {
+                sheet.cell(r, entry.getKey()).applyStyle(entry.getValue());
+            }
+        }
+
+        for (Map.Entry<Integer, Integer> entry : columnWidths.entrySet()) {
+            sheet.setColumnWidth(entry.getKey(), entry.getValue());
+        }
+
+        if (autoSize && columnWidths.isEmpty()) {
+            sheet.autoSizeAllColumns();
+        }
+        if (freezeHeader) {
+            sheet.freezePane(headerRow + 1, 1);
+        }
+        if (autoFilter) {
+            sheet.enableAutoFilter(headerRow, 1, headers.length);
+        }
+        return sheet;
+    }
+
+    private static List<Field> getExcelFields(Class<?> clazz) {
+        List<Field> result = new ArrayList<>();
+        for (Class<?> c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            Field[] declared = c.getDeclaredFields();
+            Arrays.stream(declared)
+                    .filter(f -> f.isAnnotationPresent(ExcelColumn.class))
+                    .forEach(result::add);
+        }
+        result.sort((a, b) -> Integer.compare(
+                a.getAnnotation(ExcelColumn.class).order(),
+                b.getAnnotation(ExcelColumn.class).order()));
+        return result;
+    }
+}

--- a/src/test/java/solutions/bismi/excel/ExcelCellTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelCellTest.java
@@ -290,33 +290,33 @@ class ExcelCellTest {
 
         // Test null values
         ExcelCell nullCell = sh1.cell(1, 1);
-        Assertions.assertTrue(nullCell.setText(null), "Should handle null text value");
+        Assertions.assertSame(nullCell, nullCell.setText(null), "setText(null) should return the same cell");
         Assertions.assertEquals("", nullCell.getTextValue(), "Null text should be converted to empty string");
         sh1.saveWorkBook();
         // Test empty string
         ExcelCell emptyCell = sh1.cell(1, 2);
-        Assertions.assertTrue(emptyCell.setText(""), "Should handle empty string");
+        Assertions.assertSame(emptyCell, emptyCell.setText(""), "setText(\"\") should return the same cell");
         Assertions.assertEquals("", emptyCell.getTextValue(), "Empty string should be preserved");
         sh1.saveWorkBook();
         // Test very long text
         String longText = "x".repeat(32767); // Maximum cell text length
         ExcelCell longTextCell = sh1.cell(1, 3);
-        Assertions.assertTrue(longTextCell.setText(longText), "Should handle maximum length text");
+        Assertions.assertSame(longTextCell, longTextCell.setText(longText), "setText(longText) should return the same cell");
         Assertions.assertEquals(longText, longTextCell.getTextValue(), "Long text should be preserved");
         sh1.saveWorkBook();
         // Test invalid numeric values
         ExcelCell invalidNumericCell = sh1.cell(1, 4);
-        Assertions.assertTrue(invalidNumericCell.setNumericValue(Double.NaN), "Should handle NaN");
-        Assertions.assertTrue(invalidNumericCell.setNumericValue(Double.POSITIVE_INFINITY), "Should handle infinity");
-        Assertions.assertTrue(invalidNumericCell.setNumericValue(Double.NEGATIVE_INFINITY), "Should handle negative infinity");
+        Assertions.assertSame(invalidNumericCell, invalidNumericCell.setNumericValue(Double.NaN), "setNumericValue(NaN) should return the same cell");
+        Assertions.assertSame(invalidNumericCell, invalidNumericCell.setNumericValue(Double.POSITIVE_INFINITY), "setNumericValue(+Inf) should return the same cell");
+        Assertions.assertSame(invalidNumericCell, invalidNumericCell.setNumericValue(Double.NEGATIVE_INFINITY), "setNumericValue(-Inf) should return the same cell");
         sh1.saveWorkBook();
         // Test invalid date values
         ExcelCell invalidDateCell = sh1.cell(1, 5);
-        Assertions.assertTrue(invalidDateCell.setDateValue(null), "Should handle null date");
+        Assertions.assertSame(invalidDateCell, invalidDateCell.setDateValue(null), "setDateValue(null) should return the same cell");
         sh1.saveWorkBook();
         // Test invalid formula
         ExcelCell invalidFormulaCell = sh1.cell(1, 6);
-        Assertions.assertTrue(invalidFormulaCell.setFormula("=INVALID_FORMULA()"), "Should handle invalid formula");
+        Assertions.assertSame(invalidFormulaCell, invalidFormulaCell.setFormula("=INVALID_FORMULA()"), "setFormula(invalid) should return the same cell");
         sh1.saveWorkBook();
         // Test invalid color values
         ExcelCell invalidColorCell = sh1.cell(1, 7);
@@ -327,12 +327,12 @@ class ExcelCellTest {
 
         // Test invalid alignment values
         ExcelCell invalidAlignCell = sh1.cell(1, 8);
-        Assertions.assertTrue(invalidAlignCell.setHorizontalAlignment("INVALID_ALIGNMENT"), "Should handle invalid horizontal alignment");
-        Assertions.assertTrue(invalidAlignCell.setVerticalAlignment("INVALID_ALIGNMENT"), "Should handle invalid vertical alignment");
+        Assertions.assertSame(invalidAlignCell, invalidAlignCell.setHorizontalAlignment("INVALID_ALIGNMENT"), "setHorizontalAlignment(invalid) should return the same cell");
+        Assertions.assertSame(invalidAlignCell, invalidAlignCell.setVerticalAlignment("INVALID_ALIGNMENT"), "setVerticalAlignment(invalid) should return the same cell");
         sh1.saveWorkBook();
         // Test invalid number format
         ExcelCell invalidFormatCell = sh1.cell(1, 9);
-        Assertions.assertTrue(invalidFormatCell.setNumberFormat("INVALID_FORMAT"), "Should handle invalid number format");
+        Assertions.assertSame(invalidFormatCell, invalidFormatCell.setNumberFormat("INVALID_FORMAT"), "setNumberFormat(invalid) should return the same cell");
         sh1.saveWorkBook();
         sh1.saveWorkBook();
         xlApp.closeAllWorkBooks();
@@ -641,5 +641,100 @@ class ExcelCellTest {
 
         sh1.saveWorkBook();
         xlApp.closeAllWorkBooks();
+    }
+
+    @Test
+    void mSetValuePolymorphic() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellSetValue.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("V");
+
+        sh.cell(1, 1).setValue("hello");
+        sh.cell(1, 2).setValue(42);
+        sh.cell(1, 3).setValue(3.14);
+        sh.cell(1, 4).setValue(true);
+        sh.cell(1, 5).setValue(new java.util.Date(0L));
+        sh.cell(1, 6).setValue((Object) null);
+
+        org.apache.poi.ss.usermodel.Sheet raw = wb.getWb().getSheet("V");
+        Assertions.assertEquals("hello", raw.getRow(0).getCell(0).getStringCellValue());
+        Assertions.assertEquals(42.0,    raw.getRow(0).getCell(1).getNumericCellValue(), 0.0001);
+        Assertions.assertEquals(3.14,    raw.getRow(0).getCell(2).getNumericCellValue(), 0.0001);
+        Assertions.assertTrue(raw.getRow(0).getCell(3).getBooleanCellValue());
+        Assertions.assertNotNull(raw.getRow(0).getCell(4).getDateCellValue());
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.CellType.BLANK,
+                raw.getRow(0).getCell(5).getCellType());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void nSetValueWithLocalDateAndLocalDateTime() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellLocalDate.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("D");
+
+        sh.cell(1, 1).setValue(java.time.LocalDate.of(2026, 4, 21));
+        sh.cell(1, 2).setValue(java.time.LocalDateTime.of(2026, 4, 21, 12, 0));
+
+        org.apache.poi.ss.usermodel.Sheet raw = wb.getWb().getSheet("D");
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.CellType.NUMERIC,
+                raw.getRow(0).getCell(0).getCellType());
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.CellType.NUMERIC,
+                raw.getRow(0).getCell(1).getCellType());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void oApplyStyleToCellChangesFormat() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellApplyStyle.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        sh.cell(1, 1).setValue(1000.5).applyStyle(ExcelStyle.currency());
+
+        org.apache.poi.ss.usermodel.Cell raw = wb.getWb().getSheet("S").getRow(0).getCell(0);
+        Assertions.assertTrue(raw.getCellStyle().getDataFormatString().contains("$"));
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void pSetHyperlinkCreatesLink() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellHyperlink.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("H");
+
+        sh.cell(1, 1).setHyperlink("https://example.com", "Example");
+
+        org.apache.poi.ss.usermodel.Cell raw = wb.getWb().getSheet("H").getRow(0).getCell(0);
+        Assertions.assertNotNull(raw.getHyperlink());
+        Assertions.assertEquals("https://example.com", raw.getHyperlink().getAddress());
+        Assertions.assertEquals("Example", raw.getStringCellValue());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void qSetCommentAttachesComment() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellComment.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("C");
+
+        sh.cell(2, 2).setValue("Data");
+        sh.cell(2, 2).setComment("This is a note", "Tester");
+
+        org.apache.poi.ss.usermodel.Cell raw = wb.getWb().getSheet("C").getRow(1).getCell(1);
+        Assertions.assertNotNull(raw.getCellComment());
+        Assertions.assertEquals("This is a note", raw.getCellComment().getString().getString());
+        Assertions.assertEquals("Tester", raw.getCellComment().getAuthor());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
     }
 }

--- a/src/test/java/solutions/bismi/excel/ExcelCellTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelCellTest.java
@@ -737,4 +737,51 @@ class ExcelCellTest {
         sh.saveWorkBook();
         app.closeAllWorkBooks();
     }
+
+    @Test
+    void rSetFillColorHexOnXLSX() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellHexFill.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("H");
+
+        sh.cell(1, 1).setText("header").setFillColor("#2d6cdf");
+        sh.cell(2, 1).setText("zebra").setFillColor("#f3f6f9");
+
+        org.apache.poi.xssf.usermodel.XSSFCell c1 =
+                (org.apache.poi.xssf.usermodel.XSSFCell) wb.getWb().getSheet("H").getRow(0).getCell(0);
+        org.apache.poi.xssf.usermodel.XSSFCell c2 =
+                (org.apache.poi.xssf.usermodel.XSSFCell) wb.getWb().getSheet("H").getRow(1).getCell(0);
+
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                c1.getCellStyle().getFillPattern());
+        byte[] rgb1 = c1.getCellStyle().getFillForegroundXSSFColor().getRGB();
+        Assertions.assertEquals((byte) 0x2d, rgb1[0]);
+        Assertions.assertEquals((byte) 0x6c, rgb1[1]);
+        Assertions.assertEquals((byte) 0xdf, rgb1[2]);
+
+        byte[] rgb2 = c2.getCellStyle().getFillForegroundXSSFColor().getRGB();
+        Assertions.assertEquals((byte) 0xf3, rgb2[0]);
+        Assertions.assertEquals((byte) 0xf6, rgb2[1]);
+        Assertions.assertEquals((byte) 0xf9, rgb2[2]);
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void sSetFillColorHexOnXLSFallsBackToIndexed() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/cellHexFill.xls");
+        ExcelWorkSheet sh = wb.addSheet("H");
+
+        // Should not throw — picks closest indexed color for HSSF
+        Assertions.assertDoesNotThrow(() -> sh.cell(1, 1).setText("x").setFillColor("#2d6cdf"));
+
+        org.apache.poi.ss.usermodel.Cell raw = wb.getWb().getSheet("H").getRow(0).getCell(0);
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                raw.getCellStyle().getFillPattern());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
 }

--- a/src/test/java/solutions/bismi/excel/ExcelCollectionsTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelCollectionsTest.java
@@ -1,0 +1,129 @@
+package solutions.bismi.excel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class ExcelCollectionsTest {
+
+    public static class Person {
+        @ExcelColumn(name = "Id",   order = 1) int    id;
+        @ExcelColumn(name = "Name", order = 2) String name;
+        @ExcelColumn(name = "Age",  order = 3) int    age;
+        @ExcelColumn(name = "Pro",  order = 4) boolean pro;
+
+        public Person() {}
+        public Person(int id, String name, int age, boolean pro) {
+            this.id = id; this.name = name; this.age = age; this.pro = pro;
+        }
+    }
+
+    @Test
+    void aWriteMapsThenReadAsMapsRoundTrip() {
+        String path = "./resources/testdata/writeMaps.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("Maps");
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        rows.add(ordered("Item", "Apple", "Qty", 10, "Price", 1.2));
+        rows.add(ordered("Item", "Pear",  "Qty",  8, "Price", 1.8));
+        sh.writeMaps(rows);
+        app.closeAllWorkBooks();
+
+        ExcelApplication app2 = new ExcelApplication();
+        ExcelWorkBook wb2 = app2.openWorkbook(path);
+        ExcelWorkSheet sh2 = wb2.getExcelSheet("Maps");
+        List<Map<String, String>> read = sh2.readAsMaps();
+
+        Assertions.assertEquals(2, read.size());
+        Assertions.assertEquals("Apple", read.get(0).get("Item"));
+        Assertions.assertEquals("10",    read.get(0).get("Qty"));
+        Assertions.assertEquals("Pear",  read.get(1).get("Item"));
+        app2.closeAllWorkBooks();
+    }
+
+    @Test
+    void bWriteMapsEmptyListIsNoOp() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/writeMapsEmpty.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("Empty");
+        Assertions.assertDoesNotThrow(() -> sh.writeMaps(null));
+        Assertions.assertDoesNotThrow(() -> sh.writeMaps(new ArrayList<>()));
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void cWriteBeansThenReadAsBeansRoundTrip() {
+        String path = "./resources/testdata/writeBeans.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("People");
+
+        List<Person> people = Arrays.asList(
+                new Person(1, "Alice", 30, true),
+                new Person(2, "Bob",   25, false),
+                new Person(3, "Carol", 40, true));
+        sh.writeBeans(people);
+        app.closeAllWorkBooks();
+
+        ExcelApplication app2 = new ExcelApplication();
+        ExcelWorkBook wb2 = app2.openWorkbook(path);
+        ExcelWorkSheet sh2 = wb2.getExcelSheet("People");
+        List<Person> read = sh2.readAsBeans(Person.class);
+
+        Assertions.assertEquals(3, read.size());
+        Assertions.assertEquals(1,       read.get(0).id);
+        Assertions.assertEquals("Alice", read.get(0).name);
+        Assertions.assertEquals(30,      read.get(0).age);
+        Assertions.assertTrue(read.get(0).pro);
+        Assertions.assertFalse(read.get(1).pro);
+        app2.closeAllWorkBooks();
+    }
+
+    @Test
+    void dReadAsMapsEmptySheetReturnsEmpty() {
+        String path = "./resources/testdata/emptyMaps.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("Blank");
+        Assertions.assertTrue(sh.readAsMaps().isEmpty());
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void eExcelColumnAnnotationMetadata() throws Exception {
+        java.lang.reflect.Field idField = Person.class.getDeclaredField("id");
+        ExcelColumn ann = idField.getAnnotation(ExcelColumn.class);
+        Assertions.assertNotNull(ann);
+        Assertions.assertEquals("Id", ann.name());
+        Assertions.assertEquals(1, ann.order());
+        Assertions.assertEquals("", ann.format());
+    }
+
+    @Test
+    void fWriteBeansWithNoAnnotationsIsNoOp() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/beansNoAnn.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("X");
+        List<String> plainStrings = Arrays.asList("a", "b");
+        Assertions.assertDoesNotThrow(() -> sh.writeBeans(plainStrings));
+        app.closeAllWorkBooks();
+    }
+
+    private static Map<String, Object> ordered(Object... kv) {
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+}

--- a/src/test/java/solutions/bismi/excel/ExcelRowTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelRowTest.java
@@ -344,4 +344,83 @@ class ExcelRowTest {
         xlApp.closeAllWorkBooks();
     }
 
+    @Test
+    void iSetValuesMixedTypes() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/rowSetValues.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("V");
+
+        Object[] mixed = {"Widget", 10, 12.50, true, new java.util.Date(0L), null};
+        sh.row(1).setValues(mixed);
+
+        org.apache.poi.ss.usermodel.Row raw = wb.getWb().getSheet("V").getRow(0);
+        Assertions.assertEquals("Widget", raw.getCell(0).getStringCellValue());
+        Assertions.assertEquals(10.0,     raw.getCell(1).getNumericCellValue(), 0.0001);
+        Assertions.assertEquals(12.50,    raw.getCell(2).getNumericCellValue(), 0.0001);
+        Assertions.assertTrue(raw.getCell(3).getBooleanCellValue());
+        Assertions.assertNotNull(raw.getCell(4).getDateCellValue());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void jSetValuesWithStartColumn() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/rowSetValuesOffset.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("V");
+
+        sh.row(1).setValues(new Object[]{"a", "b"}, 3);
+        org.apache.poi.ss.usermodel.Row raw = wb.getWb().getSheet("V").getRow(0);
+        Assertions.assertEquals("a", raw.getCell(2).getStringCellValue());
+        Assertions.assertEquals("b", raw.getCell(3).getStringCellValue());
+        Assertions.assertNull(raw.getCell(0));
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void kApplyStyleToRowAffectsAllCells() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/rowApplyStyle.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        sh.row(1).setRowValues(new String[]{"A", "B", "C"});
+        sh.row(1).applyStyle(ExcelStyle.header());
+
+        org.apache.poi.ss.usermodel.Row raw = wb.getWb().getSheet("S").getRow(0);
+        for (int c = 0; c < 3; c++) {
+            Assertions.assertEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                    raw.getCell(c).getCellStyle().getFillPattern());
+            Assertions.assertTrue(
+                    wb.getWb().getFontAt(raw.getCell(c).getCellStyle().getFontIndex()).getBold());
+        }
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void lApplyStyleRangeOnlyAffectsRange() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/rowApplyStyleRange.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        sh.row(1).setRowValues(new String[]{"A", "B", "C", "D"});
+        sh.row(1).applyStyle(ExcelStyle.builder().fillColor("yellow").build(), 2, 4);
+
+        org.apache.poi.ss.usermodel.Row raw = wb.getWb().getSheet("S").getRow(0);
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                raw.getCell(1).getCellStyle().getFillPattern());
+        Assertions.assertEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                raw.getCell(2).getCellStyle().getFillPattern());
+        Assertions.assertNotEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                raw.getCell(0).getCellStyle().getFillPattern());
+        Assertions.assertNotEquals(org.apache.poi.ss.usermodel.FillPatternType.SOLID_FOREGROUND,
+                raw.getCell(3).getCellStyle().getFillPattern());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
 }

--- a/src/test/java/solutions/bismi/excel/ExcelStyleTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelStyleTest.java
@@ -1,0 +1,87 @@
+package solutions.bismi.excel;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class ExcelStyleTest {
+
+    @Test
+    void aBuilderProducesExpectedFields() {
+        ExcelStyle style = ExcelStyle.builder()
+                .fontColor("white")
+                .fillColor("grey_50_percent")
+                .fullBorder("black")
+                .horizontalAlignment("CENTER")
+                .verticalAlignment("TOP")
+                .numberFormat("#,##0.00")
+                .bold(true)
+                .italic(true)
+                .underline(true)
+                .build();
+
+        Assertions.assertEquals("white", style.getFontColor());
+        Assertions.assertEquals("grey_50_percent", style.getFillColor());
+        Assertions.assertEquals("black", style.getBorderColor());
+        Assertions.assertEquals("CENTER", style.getHorizontalAlignment());
+        Assertions.assertEquals("TOP", style.getVerticalAlignment());
+        Assertions.assertEquals("#,##0.00", style.getNumberFormat());
+        Assertions.assertTrue(style.isBold());
+        Assertions.assertTrue(style.isItalic());
+        Assertions.assertTrue(style.isUnderline());
+    }
+
+    @Test
+    void bPresetsAreNonNull() {
+        Assertions.assertNotNull(ExcelStyle.header());
+        Assertions.assertNotNull(ExcelStyle.zebraStripe());
+        Assertions.assertNotNull(ExcelStyle.currency());
+        Assertions.assertNotNull(ExcelStyle.percent());
+        Assertions.assertNotNull(ExcelStyle.date());
+        Assertions.assertEquals("$#,##0.00", ExcelStyle.currency().getNumberFormat());
+        Assertions.assertEquals("0.00%", ExcelStyle.percent().getNumberFormat());
+    }
+
+    @Test
+    void cApplyToNullCellIsNoOp() {
+        Assertions.assertDoesNotThrow(() -> ExcelStyle.header().applyTo(null));
+    }
+
+    @Test
+    void dApplyToCellActuallyChangesStyle() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/styleApply.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        ExcelStyle money = ExcelStyle.builder()
+                .fillColor("yellow")
+                .numberFormat("$#,##0.00")
+                .horizontalAlignment("RIGHT")
+                .build();
+
+        sh.cell(1, 1).setValue(123.45).applyStyle(money);
+        sh.saveWorkBook();
+
+        Cell raw = wb.getWb().getSheet("S").getRow(0).getCell(0);
+        CellStyle cs = raw.getCellStyle();
+        Assertions.assertEquals(FillPatternType.SOLID_FOREGROUND, cs.getFillPattern());
+        Assertions.assertTrue(cs.getDataFormatString().contains("$"));
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void eNullStyleIsNoOp() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/styleNull.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+        Assertions.assertDoesNotThrow(() -> sh.cell(1, 1).applyStyle(null));
+        Assertions.assertDoesNotThrow(() -> sh.row(1).applyStyle(null));
+        app.closeAllWorkBooks();
+    }
+}

--- a/src/test/java/solutions/bismi/excel/ExcelWorkSheetTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelWorkSheetTest.java
@@ -274,4 +274,70 @@ class ExcelWorkSheetTest {
         new ExcelWorkSheet(null, null, null, null);
         new ExcelWorkSheet(null, "sheet", null, null, null, "file.xlsx");
     }
+
+    @Test
+    void zaFreezePaneSetsCorrectSplit() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/sheetFreeze.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("F");
+        sh.cell(1, 1).setText("h");
+        sh.freezePane(2, 1);
+
+        org.apache.poi.xssf.usermodel.XSSFSheet xs =
+                (org.apache.poi.xssf.usermodel.XSSFSheet) wb.getWb().getSheet("F");
+        org.openxmlformats.schemas.spreadsheetml.x2006.main.CTPane pane =
+                xs.getCTWorksheet().getSheetViews().getSheetViewArray(0).getPane();
+        Assertions.assertNotNull(pane);
+        Assertions.assertEquals(1.0, pane.getYSplit(), 0.0001);
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void zbEnableAutoFilterSetsRange() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/sheetAutoFilter.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("A");
+        sh.row(1).setRowValues(new String[]{"A", "B", "C"});
+        sh.enableAutoFilter(1, 1, 3);
+
+        org.apache.poi.xssf.usermodel.XSSFSheet xs =
+                (org.apache.poi.xssf.usermodel.XSSFSheet) wb.getWb().getSheet("A");
+        Assertions.assertNotNull(xs.getCTWorksheet().getAutoFilter());
+        Assertions.assertEquals("A1:C1", xs.getCTWorksheet().getAutoFilter().getRef());
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void zcSetColumnWidthAppliesExactly() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/sheetColWidth.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("W");
+        sh.setColumnWidth(1, 25);
+
+        Assertions.assertEquals(25 * 256, wb.getWb().getSheet("W").getColumnWidth(0));
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void zdAutoSizeAllColumnsDoesNotThrow() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/sheetAutoSize.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("A");
+        sh.row(1).setRowValues(new String[]{"short", "a longer piece of text"});
+        Assertions.assertDoesNotThrow(sh::autoSizeAllColumns);
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void zeProtectSheetWithPassword() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/sheetProtect.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("P");
+        sh.protect("secret");
+
+        Assertions.assertTrue(wb.getWb().getSheet("P").getProtect());
+        app.closeAllWorkBooks();
+    }
 }

--- a/src/test/java/solutions/bismi/excel/ReadmeSnippetsTest.java
+++ b/src/test/java/solutions/bismi/excel/ReadmeSnippetsTest.java
@@ -1,0 +1,223 @@
+package solutions.bismi.excel;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Every code block visible in the README is reproduced here verbatim and executed.
+ * If a snippet drifts from the real API, this class stops compiling or fails —
+ * making README code a build-time invariant, not a hope.
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class ReadmeSnippetsTest {
+
+    public static class Product {
+        @ExcelColumn(name = "SKU",   order = 1)                      String sku;
+        @ExcelColumn(name = "Item",  order = 2)                      String name;
+        @ExcelColumn(name = "Units", order = 3, format = "#,##0")    int    units;
+        @ExcelColumn(name = "Price", order = 4, format = "$#,##0.00") double price;
+
+        public Product() {}
+        public Product(String sku, String name, int units, double price) {
+            this.sku = sku; this.name = name; this.units = units; this.price = price;
+        }
+    }
+
+    // README — "Hook" block: ReportBuilder on beans
+    @Test
+    void aHookSnippetRendersFromBeans() {
+        List<Product> products = Arrays.asList(
+                new Product("A-100", "Widget",  120, 12.50),
+                new Product("A-101", "Gadget",   85, 24.00));
+
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeHook.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("Sales");
+
+        // --- snippet begin ---
+        ReportBuilder.on(sheet)
+            .title("Q3 Sales Report")
+            .rowsFromBeans(products)
+            .zebraStripes(true).freezeHeader(true).autoFilter(true)
+            .render();
+        // --- snippet end ---
+
+        Assertions.assertEquals("Q3 Sales Report",
+                wb.getWb().getSheet("Sales").getRow(0).getCell(0).getStringCellValue());
+        app.closeAllWorkBooks();
+    }
+
+    // README — "1 · Hello, styled workbook (6 lines)"
+    @Test
+    void bHelloStyledWorkbookSixLines() {
+        // --- snippet begin ---
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeHello.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("Summary");
+        sh.cell(1,1).setText("Hello World").applyStyle(ExcelStyle.header());
+        wb.saveWorkbook();
+        app.closeAllWorkBooks();
+        // --- snippet end ---
+
+        ExcelApplication a2 = new ExcelApplication();
+        ExcelWorkBook w2 = a2.openWorkbook("./resources/testdata/readmeHello.xlsx");
+        Assertions.assertEquals("Hello World",
+                w2.getWb().getSheet("Summary").getRow(0).getCell(0).getStringCellValue());
+        a2.closeAllWorkBooks();
+    }
+
+    // README — "2 · Bean → styled report (one call)"
+    @Test
+    void cBeanToStyledReportOneCall() {
+        List<Product> productList = Arrays.asList(new Product("X", "Thing", 1, 1.00));
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeBean.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("Catalog");
+
+        // --- snippet begin ---
+        ReportBuilder.on(sheet)
+            .title("Catalog")
+            .rowsFromBeans(productList)
+            .zebraStripes(true).freezeHeader(true).autoFilter(true)
+            .render();
+        // --- snippet end ---
+
+        Assertions.assertEquals("Catalog",
+                wb.getWb().getSheet("Catalog").getRow(0).getCell(0).getStringCellValue());
+        app.closeAllWorkBooks();
+    }
+
+    // README — "3 · List<Map> → spreadsheet"
+    @Test
+    void dListMapToSpreadsheet() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeMaps.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("M");
+
+        // --- snippet begin ---
+        List<Map<String,Object>> rows = List.of(
+            ordered("Item","Apple", "Qty",10, "Price",1.20),
+            ordered("Item","Pear",  "Qty", 8, "Price",1.80));
+
+        sheet.writeMaps(rows).freezePane(2,1).autoSizeAllColumns();
+        // --- snippet end ---
+
+        Assertions.assertEquals("Apple",
+                wb.getWb().getSheet("M").getRow(1).getCell(0).getStringCellValue());
+        app.closeAllWorkBooks();
+    }
+
+    // README — "4 · Read Excel → List<Bean>"
+    @Test
+    void eReadExcelToListOfBeans() {
+        String path = "./resources/testdata/readmeRead.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sheet = wb.addSheet("P");
+        sheet.writeBeans(Arrays.asList(
+                new Product("A", "Alpha", 5, 10.00),
+                new Product("B", "Beta",  6, 20.00)));
+        app.closeAllWorkBooks();
+
+        ExcelApplication app2 = new ExcelApplication();
+        ExcelWorkBook wb2 = app2.openWorkbook(path);
+        ExcelWorkSheet sheet2 = wb2.getExcelSheet("P");
+
+        // --- snippet begin ---
+        List<Product> products = sheet2.readAsBeans(Product.class);
+        // --- snippet end ---
+
+        Assertions.assertEquals(2, products.size());
+        Assertions.assertEquals("Alpha", products.get(0).name);
+        Assertions.assertEquals(5, products.get(0).units);
+        app2.closeAllWorkBooks();
+    }
+
+    // README — "5 · Reusable style, applied 1,000 times"
+    @Test
+    void fReusableStyleApplied1000Times() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeReuse.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("R");
+        double[] revenue = new double[1000];
+        for (int i = 0; i < 1000; i++) revenue[i] = 100.0 + i;
+
+        // --- snippet begin ---
+        ExcelStyle money = ExcelStyle.builder()
+                .numberFormat("$#,##0.00").horizontalAlignment("RIGHT").fullBorder("black").build();
+
+        for (int r = 2; r <= 1001; r++) {
+            sheet.cell(r, 3).setValue(revenue[r-2]).applyStyle(money);
+        }
+        // --- snippet end ---
+
+        Assertions.assertEquals(100.0,
+                wb.getWb().getSheet("R").getRow(1).getCell(2).getNumericCellValue(), 0.0001);
+        app.closeAllWorkBooks();
+    }
+
+    // README — "6 · Hyperlinks & comments"
+    @Test
+    void gHyperlinksAndComments() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeHyperlinks.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("H");
+
+        // --- snippet begin ---
+        sheet.cell(1,1).setHyperlink("https://bismi.solutions", "Bismi Solutions");
+        sheet.cell(1,1).setComment("Official site", "Release notes");
+        // --- snippet end ---
+
+        org.apache.poi.ss.usermodel.Cell c = wb.getWb().getSheet("H").getRow(0).getCell(0);
+        Assertions.assertNotNull(c.getHyperlink());
+        Assertions.assertNotNull(c.getCellComment());
+        app.closeAllWorkBooks();
+    }
+
+    // README — "Style reuse at a glance"
+    @Test
+    void hStyleReuseAtAGlance() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeStyleReuse.xlsx");
+        ExcelWorkSheet sheet = wb.addSheet("S");
+
+        // --- snippet begin ---
+        ExcelStyle header = ExcelStyle.header();
+        ExcelStyle zebra  = ExcelStyle.zebraStripe();
+        ExcelStyle money  = ExcelStyle.currency();
+        ExcelStyle pct    = ExcelStyle.percent();
+        ExcelStyle when   = ExcelStyle.date();
+
+        ExcelStyle custom = ExcelStyle.builder()
+                .fontColor("white").fillColor("#0d4ba1")
+                .bold(true).horizontalAlignment("CENTER").fullBorder("black")
+                .build();
+
+        sheet.row(1).applyStyle(header);
+        sheet.row(5).applyStyle(money, 2, 6);            // cells 2..5 of row 5
+        sheet.cell(10,3).applyStyle(money);              // single cell
+        // --- snippet end ---
+
+        Assertions.assertNotNull(header);
+        Assertions.assertNotNull(zebra);
+        Assertions.assertNotNull(pct);
+        Assertions.assertNotNull(when);
+        Assertions.assertNotNull(custom);
+        app.closeAllWorkBooks();
+    }
+
+    private static Map<String, Object> ordered(Object... kv) {
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+}

--- a/src/test/java/solutions/bismi/excel/ReadmeSnippetsTest.java
+++ b/src/test/java/solutions/bismi/excel/ReadmeSnippetsTest.java
@@ -181,6 +181,34 @@ class ReadmeSnippetsTest {
         app.closeAllWorkBooks();
     }
 
+    // README — "Rows from arrays — one call writes the whole row"
+    @Test
+    void iRowsFromArrays() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/readmeRowArrays.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        // --- snippet begin ---
+        // Header row from a String[]
+        String[] headers = {"Item", "Qty", "Unit", "Aisle"};
+        sh.row(2).setRowValues(headers);
+
+        // Data rows from Object[] — mixed types get routed automatically
+        sh.row(3).setValues(new Object[]{"Apples",  6, "pcs", "Produce"});
+        sh.row(4).setValues(new Object[]{"Milk",    2, "L",   "Dairy"});
+        // --- snippet end ---
+
+        org.apache.poi.ss.usermodel.Sheet raw = wb.getWb().getSheet("S");
+        Assertions.assertEquals("Item",    raw.getRow(1).getCell(0).getStringCellValue());
+        Assertions.assertEquals("Aisle",   raw.getRow(1).getCell(3).getStringCellValue());
+        Assertions.assertEquals("Apples",  raw.getRow(2).getCell(0).getStringCellValue());
+        Assertions.assertEquals(6.0,       raw.getRow(2).getCell(1).getNumericCellValue(), 0.0001);
+        Assertions.assertEquals("Produce", raw.getRow(2).getCell(3).getStringCellValue());
+
+        sh.saveWorkBook();
+        app.closeAllWorkBooks();
+    }
+
     // README — "Style reuse at a glance"
     @Test
     void hStyleReuseAtAGlance() {

--- a/src/test/java/solutions/bismi/excel/ReportBuilderTest.java
+++ b/src/test/java/solutions/bismi/excel/ReportBuilderTest.java
@@ -1,0 +1,159 @@
+package solutions.bismi.excel;
+
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTPane;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class ReportBuilderTest {
+
+    public static class Sale {
+        @ExcelColumn(name = "Region", order = 1)                          String region;
+        @ExcelColumn(name = "Units",  order = 2, format = "#,##0")        int units;
+        @ExcelColumn(name = "Revenue",order = 3, format = "$#,##0.00")    double revenue;
+
+        public Sale() {}
+        public Sale(String region, int units, double revenue) {
+            this.region = region; this.units = units; this.revenue = revenue;
+        }
+    }
+
+    @Test
+    void aRenderFromBeansWritesHeaderAndRows() {
+        String path = "./resources/testdata/reportBeans.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("Sales");
+
+        List<Sale> sales = Arrays.asList(
+                new Sale("North", 120, 1500.00),
+                new Sale("South",  85,  920.50),
+                new Sale("East",  210, 2750.00));
+
+        ReportBuilder.on(sh)
+                .title("Q3 Sales")
+                .rowsFromBeans(sales)
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .render();
+
+        Sheet raw = wb.getWb().getSheet("Sales");
+        Assertions.assertEquals("Q3 Sales", raw.getRow(0).getCell(0).getStringCellValue());
+        Assertions.assertEquals("Region",   raw.getRow(1).getCell(0).getStringCellValue());
+        Assertions.assertEquals("North",    raw.getRow(2).getCell(0).getStringCellValue());
+        Assertions.assertEquals(120d,       raw.getRow(2).getCell(1).getNumericCellValue(), 0.0001);
+        Assertions.assertEquals(1500.00,    raw.getRow(2).getCell(2).getNumericCellValue(), 0.0001);
+
+        XSSFSheet xs = (XSSFSheet) raw;
+        CTPane pane = xs.getCTWorksheet().getSheetViews().getSheetViewArray(0).getPane();
+        Assertions.assertNotNull(pane);
+        // Title row + header row → freeze below row 2, so ySplit == 2
+        Assertions.assertEquals(2.0, pane.getYSplit(), 0.0001);
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void bRenderFromMapsInfersHeaders() {
+        String path = "./resources/testdata/reportMaps.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("M");
+
+        List<Map<String, Object>> rows = Arrays.asList(
+                ordered("Name", "A", "Score", 10),
+                ordered("Name", "B", "Score", 20));
+        ReportBuilder.on(sh).rowsFromMaps(rows).render();
+
+        Sheet raw = wb.getWb().getSheet("M");
+        Assertions.assertEquals("Name", raw.getRow(0).getCell(0).getStringCellValue());
+        Assertions.assertEquals("Score", raw.getRow(0).getCell(1).getStringCellValue());
+        Assertions.assertEquals(20d, raw.getRow(2).getCell(1).getNumericCellValue(), 0.0001);
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void cRenderFromArrayRows() {
+        String path = "./resources/testdata/reportArrays.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("A");
+
+        ReportBuilder.on(sh)
+                .headers("Col1", "Col2")
+                .row("x", 1)
+                .row("y", 2)
+                .columnStyle(2, ExcelStyle.builder().numberFormat("#,##0").build())
+                .columnWidth(1, 15)
+                .render();
+
+        Sheet raw = wb.getWb().getSheet("A");
+        Assertions.assertEquals("Col1", raw.getRow(0).getCell(0).getStringCellValue());
+        Assertions.assertEquals("x",    raw.getRow(1).getCell(0).getStringCellValue());
+        Assertions.assertEquals(2d,     raw.getRow(2).getCell(1).getNumericCellValue(), 0.0001);
+        Assertions.assertEquals(15 * 256, raw.getColumnWidth(0));
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void dRenderWithoutHeadersThrows() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/reportNoHeaders.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("X");
+
+        ReportBuilder rb = ReportBuilder.on(sh);
+        Assertions.assertThrows(IllegalStateException.class, rb::render);
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void eAutoFilterAppliedOnHeader() {
+        String path = "./resources/testdata/reportFilter.xlsx";
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook(path);
+        ExcelWorkSheet sh = wb.addSheet("F");
+
+        ReportBuilder.on(sh)
+                .headers("A", "B", "C")
+                .row(1, 2, 3)
+                .autoFilter(true)
+                .render();
+
+        org.apache.poi.xssf.usermodel.XSSFSheet xs =
+                (org.apache.poi.xssf.usermodel.XSSFSheet) wb.getWb().getSheet("F");
+        Assertions.assertNotNull(xs.getCTWorksheet().getAutoFilter());
+        Assertions.assertEquals("A1:C1", xs.getCTWorksheet().getAutoFilter().getRef());
+
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void fRowsFromMapsNullIsNoOp() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/reportNullMaps.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("N");
+        Assertions.assertDoesNotThrow(() ->
+                ReportBuilder.on(sh).headers("x").rowsFromMaps(null).render());
+        app.closeAllWorkBooks();
+    }
+
+    private static Map<String, Object> ordered(Object... kv) {
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+}


### PR DESCRIPTION
## Summary

- **New public API for collection-driven reports** — `@ExcelColumn` annotation, `ExcelStyle` (immutable reusable style with 6 presets), `ReportBuilder` (one-call styled tables), and collection methods on `ExcelWorkSheet`: `writeMaps` / `writeBeans` / `readAsMaps` / `readAsBeans` with ISO-8601 date round-trip
- **Fluent cell API fix** — all `ExcelCell` setters now return `ExcelCell` (previously `boolean` / `void`), so `cell(r,c).setText(...).applyStyle(...)` actually chains. Hex fill colours now work on `.xlsx` (exact RGB) with closest-indexed fallback on `.xls`
- **Missing MS-Excel features** added to `ExcelWorkSheet`: `freezePane`, `enableAutoFilter`, `setColumnWidth`, `autoSizeAllColumns`, `protect` — plus `setValue(Object)`, `setHyperlink`, `setComment` on `ExcelCell`
- **README reorganised around why-not-POI** with an inline SVG preview of a styled report, a lines-of-code comparison table (3×–40× savings), and a tiered examples gallery: 🟢 beginner (TitleAndContent · KpiTiles · RowFromArray) then 🟠 intermediate/advanced (Invoice · Dashboard · Employee Directory · CollectionReport) — every example ships with a paired SVG mock matching the output colours
- **Test suite grew 52 → 94** — including a `ReadmeSnippetsTest` that executes every code block in the README verbatim, so docs can't drift from the API
- **pom.xml** bumps dependencies/plugins (POI 5.4.1→5.5.1, JUnit 5.10→5.13.4, Log4j 2.20→2.25.4, etc.) and version to **1.2.0**

## Visuals

Styled hero report (rendered from `ReportBuilder.rowsFromBeans(products)`):
![preview](docs/report-preview.svg)

Additional previews: [invoice](docs/invoice-preview.svg) · [dashboard](docs/dashboard-preview.svg) · [employee directory](docs/employee-preview.svg) · [KPI tiles](docs/kpi-preview.svg) · [title + content](docs/title-content-preview.svg) · [rows from arrays](docs/row-array-preview.svg)

## Test plan

- [x] `mvn test` — 94 tests, 0 failures, 0 errors
- [x] `mvn compile exec:java -Dexec.mainClass=InvoiceExample`
- [x] `mvn compile exec:java -Dexec.mainClass=DashboardExample`
- [x] `mvn compile exec:java -Dexec.mainClass=EmployeeDirectoryExample` (round-trip reads 5 employees)
- [x] `mvn compile exec:java -Dexec.mainClass=CollectionReportExample`
- [x] `mvn compile exec:java -Dexec.mainClass=KpiTilesExample`
- [x] `mvn compile exec:java -Dexec.mainClass=TitleAndContentExample`
- [x] `mvn compile exec:java -Dexec.mainClass=RowFromArrayExample`
- [x] Manual: open each generated `.xlsx` in Excel and confirm the styled primary sheet is the one that loads, colours match the SVG previews, freeze panes / auto-filter dropdowns are in place
- [ ] CI + Codecov + Sonar + Snyk (pending)

## Breaking changes

Pre-release 1.2.0 (not yet published to Maven Central). Source-level breaks on users who captured the return value of these `ExcelCell` setters:

- `setText / setCellValue / setNumericValue / setDateValue / setFormula / setHorizontalAlignment / setVerticalAlignment / setNumberFormat / setFontStyle` — `boolean` → `ExcelCell`
- `setFillColor / setFullBorder` — `void` → `ExcelCell`

Call sites that ignore the return value (the common case) are unaffected.
