### PR TITLE
Release 1.3.0 — SalesReport matches preview + CI/coverage cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    env:
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -32,10 +35,6 @@ jobs:
                 <username>${{ secrets.CENTRAL_USERNAME }}</username>
                 <password>${{ secrets.CENTRAL_PASSWORD }}</password>
               </server>
-              <server>
-                <id>gpg.passphrase</id>
-                <passphrase>${{ secrets.GPG_PASSPHRASE }}</passphrase>
-              </server>
             </servers>
           </settings>
           EOF
@@ -49,7 +48,7 @@ jobs:
         run: mvn -B verify
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI & Release](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml/badge.svg)](https://github.com/Bismi-Solutions/Excel/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/Bismi-Solutions/Excel/branch/master/graph/badge.svg)](https://codecov.io/gh/Bismi-Solutions/Excel)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Bismi-Solutions_Excel&metric=alert_status)](https://sonarcloud.io/project/overview?id=Bismi-Solutions_Excel)
-[![Known Vulnerabilities](https://snyk.io/test/github/Bismi-Solutions/Excel/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/Bismi-Solutions/Excel?targetFile=pom.xml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Bismi-Solutions/Excel/badge)](https://scorecard.dev/viewer/?uri=github.com/Bismi-Solutions/Excel)
 [![Maven Central](https://img.shields.io/maven-central/v/solutions.bismi.excel/excel.svg)](https://search.maven.org/artifact/solutions.bismi.excel/excel)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Java Version](https://img.shields.io/badge/Java-17%2B-blue)](https://openjdk.java.net/)
@@ -27,6 +27,8 @@ ReportBuilder.on(sheet)
 <p align="center">
   <img src="docs/report-preview.svg" alt="Styled Excel report generated in 5 lines" width="100%"/>
 </p>
+
+> The workbook shown above is produced by [`examples/SalesReport.java`](examples/SalesReport.java) — beans + `ReportBuilder`, plus the new `ExcelStyle.title()` / `totals()` / `statusActive|Review|Closed()` presets for the navy title, the pale-blue totals row and the coloured status pills.
 
 ---
 
@@ -241,18 +243,18 @@ The rest use `@ExcelColumn` bean mapping, `ReportBuilder`, formulas, hyperlinks,
 <dependency>
   <groupId>solutions.bismi.excel</groupId>
   <artifactId>excel</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 
 ### Gradle (Kotlin DSL)
 ```kotlin
-implementation("solutions.bismi.excel:excel:1.2.0")
+implementation("solutions.bismi.excel:excel:1.3.0")
 ```
 
 ### Gradle (Groovy DSL)
 ```groovy
-implementation "solutions.bismi.excel:excel:1.2.0"
+implementation "solutions.bismi.excel:excel:1.3.0"
 ```
 
 **Requires:** Java 17+  ·  Works on Windows · macOS · Linux.
@@ -271,7 +273,7 @@ implementation "solutions.bismi.excel:excel:1.2.0"
 | 🔗 **Merge/Unmerge** | succinct helpers · overlap safety checks |
 | 🗂️ **Collections** | `writeMaps` · `writeBeans` · `readAsMaps` · `readAsBeans` · `@ExcelColumn` annotation |
 | 🏗️ **Reports** | `ReportBuilder` — title · headers · zebra · freeze · auto-filter · per-column formats · column widths |
-| 🧪 **Quality** | 91 unit tests (incl. every README snippet) · CI · Codecov · Sonar · Snyk |
+| 🧪 **Quality** | 97 unit tests (incl. every README snippet) · CI · Codecov · Sonar · OpenSSF Scorecard |
 
 ---
 
@@ -337,11 +339,19 @@ flowchart LR
 ## 🧱 Style reuse at a glance
 
 ```java
-ExcelStyle header = ExcelStyle.header();         // grey fill · white bold · centred · bordered
+ExcelStyle header = ExcelStyle.header();         // blue fill · white bold · centred · bordered
 ExcelStyle zebra  = ExcelStyle.zebraStripe();    // light-grey fill
 ExcelStyle money  = ExcelStyle.currency();       // right-aligned $#,##0.00
 ExcelStyle pct    = ExcelStyle.percent();        // right-aligned 0.00%
 ExcelStyle when   = ExcelStyle.date();           // dd-MMM-yyyy
+
+// v1.3 presets — pair with ReportBuilder for polished reports
+ExcelStyle title  = ExcelStyle.title();          // navy merged title bar (pairs with header())
+ExcelStyle totals = ExcelStyle.totals();         // pale-blue totals row, navy bold text
+ExcelStyle active = ExcelStyle.statusActive();   // green pill — e.g. "Active", "OK"
+ExcelStyle review = ExcelStyle.statusReview();   // amber pill — e.g. "Review", "Pending"
+ExcelStyle closed = ExcelStyle.statusClosed();   // red pill   — e.g. "Closed", "Error"
+ExcelStyle pill   = ExcelStyle.statusPill("#e0e7ff", "#1d4ed8");  // roll your own
 
 ExcelStyle custom = ExcelStyle.builder()
         .fontColor("white").fillColor("#0d4ba1")
@@ -364,7 +374,7 @@ sheet.cell(10,3).applyStyle(money);              // single cell
 ```bash
 git clone https://github.com/Bismi-Solutions/Excel.git
 cd Excel
-mvn test        # 91 tests — all green is the baseline
+mvn test        # 97 tests — all green is the baseline
 ```
 
 PRs welcome. Please include unit tests and follow the log-level convention:

--- a/examples/SalesReport.java
+++ b/examples/SalesReport.java
@@ -1,146 +1,134 @@
-import solutions.bismi.excel.*;
+import solutions.bismi.excel.ExcelApplication;
+import solutions.bismi.excel.ExcelColumn;
+import solutions.bismi.excel.ExcelStyle;
+import solutions.bismi.excel.ExcelWorkBook;
+import solutions.bismi.excel.ExcelWorkSheet;
+import solutions.bismi.excel.ReportBuilder;
 
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * A comprehensive example demonstrating Excel library features
- * Creates a multi-sheet sales report with formatting, formulas, and charts
+ * Reproduces the styled report rendered by {@code docs/report-preview.svg} — a
+ * polished Q3 regional breakdown with a navy title, blue gradient header, zebra
+ * stripes, coloured growth arrows, status pills, a comment, and a totals row.
+ *
+ * <p>Layout (sheet <b>Summary</b>):</p>
+ * <pre>
+ *   Row 1 : merged A1:G1 — dark-navy bar "Q3 Sales Report — Regional Breakdown"
+ *   Row 2 : blue header  — Product · Units · Revenue · Growth · Launched · Owner · Status
+ *   Row 3-7: data rows with zebra stripes
+ *           Growth column turns green (▲) on positive, red (▼) on negative.
+ *           Status column renders as a coloured pill (Active / Review / Closed).
+ *   Row 8 : pale-blue totals row with navy bold text
+ * </pre>
+ *
+ * <p>The workbook also carries three empty sibling tabs (Products, Regions,
+ * Raw Data) so the Excel tab strip matches the preview.</p>
  */
 public class SalesReport {
+
+    /** Bean with {@link ExcelColumn} annotations — drives the bulk of the report. */
+    public static class Product {
+        @ExcelColumn(name = "Product",  order = 1)                                 String name;
+        @ExcelColumn(name = "Units",    order = 2, format = "#,##0")               int units;
+        @ExcelColumn(name = "Revenue",  order = 3, format = "$#,##0.00")           double revenue;
+        @ExcelColumn(name = "Growth",   order = 4, format = "\"▲ \"0.00%;\"▼ \"0.00%") double growth;
+        @ExcelColumn(name = "Launched", order = 5, format = "dd-MMM-yyyy")         LocalDate launched;
+        @ExcelColumn(name = "Owner",    order = 6)                                 String owner;
+        @ExcelColumn(name = "Status",   order = 7)                                 String status;
+
+        public Product() {}
+        public Product(String name, int units, double revenue, double growth,
+                       LocalDate launched, String owner, String status) {
+            this.name = name; this.units = units; this.revenue = revenue;
+            this.growth = growth; this.launched = launched;
+            this.owner = owner; this.status = status;
+        }
+    }
+
     public static void main(String[] args) {
         ExcelApplication app = new ExcelApplication();
-        ExcelWorkBook wb = app.createWorkBook("SalesReport.xlsx");
-        
-        // Create Summary sheet
-        ExcelWorkSheet summary = wb.addSheet("Summary");
-        summary.activate();
-        createSummarySheet(summary);
-        
-        // Create Sales Data sheet
-        ExcelWorkSheet sales = wb.addSheet("Sales Data");
-        createSalesDataSheet(sales);
-        
-        // Create Charts sheet
-        ExcelWorkSheet charts = wb.addSheet("Charts");
-        createChartsSheet(charts, sales);
-        
-        // Save and close
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/salesReport.xlsx");
+
+        buildSummary(wb);
+        wb.addSheet("Products");
+        wb.addSheet("Regions");
+        wb.addSheet("Raw Data");
+
         wb.saveWorkbook();
         app.closeAllWorkBooks();
+        System.out.println("Sales report written to ./resources/testdata/salesReport.xlsx");
     }
-    
-    private static void createSummarySheet(ExcelWorkSheet sheet) {
-        // Title
-        sheet.cell(1, 1).setText("Q1 2024 Sales Report");
-        sheet.cell(1, 1).setFontStyle(true, false, false);
-        sheet.cell(1, 1).setHorizontalAlignment("CENTER");
-        sheet.mergeCells(1, 1, 1, 5);
-        
-        // Summary metrics
-        String[] metrics = {"Total Sales", "Average Order", "Top Product", "Growth"};
-        String[] values = {"=SUM('Sales Data'!B2:B31)", "=AVERAGE('Sales Data'!B2:B31)", 
-                          "=INDEX('Sales Data'!A2:A31,MATCH(MAX('Sales Data'!B2:B31),'Sales Data'!B2:B31,0))",
-                          "=((SUM('Sales Data'!B2:B31)-SUM('Sales Data'!C2:C31))/SUM('Sales Data'!C2:C31))"};
-        
-        for (int i = 0; i < metrics.length; i++) {
-            sheet.cell(3, i+1).setText(metrics[i]);
-            sheet.cell(3, i+1).setFontStyle(true, false, false);
-            sheet.cell(3, i+1).setFillColor("grey_25_percent");
-            sheet.cell(4, i+1).setFormula(values[i]);
-            if (i < 2) {
-                sheet.cell(4, i+1).setNumberFormat("$#,##0.00");
-            } else if (i == 3) {
-                sheet.cell(4, i+1).setNumberFormat("0.00%");
-            } else {
-                sheet.cell(4, i+1).setNumberFormat("@");
-            }
-        }
-        
-        // Format summary section
-        sheet.cell(3, 1).setFullBorder("black");
-        sheet.cell(3, 4).setFullBorder("black");
-        sheet.cell(4, 1).setFullBorder("black");
-        sheet.cell(4, 4).setFullBorder("black");
-    }
-    
-    private static void createSalesDataSheet(ExcelWorkSheet sheet) {
-        // Headers
-        String[] headers = {"Product", "Current Sales", "Previous Sales", "Growth", "Category"};
-        for (int i = 0; i < headers.length; i++) {
-            sheet.cell(1, i+1).setText(headers[i]);
-            sheet.cell(1, i+1).setFontStyle(true, false, false);
-            sheet.cell(1, i+1).setFillColor("grey_25_percent");
-            sheet.cell(1, i+1).setHorizontalAlignment("CENTER");
-        }
-        
-        // Sample data
+
+    private static void buildSummary(ExcelWorkBook wb) {
+        ExcelWorkSheet sh = wb.addSheet("Summary");
+        sh.activate();
+
         List<Product> products = Arrays.asList(
-            new Product("Laptop Pro", 125000, 100000, "Electronics"),
-            new Product("Smartphone X", 150000, 120000, "Electronics"),
-            new Product("Office Chair", 45000, 40000, "Furniture"),
-            new Product("Desk Lamp", 25000, 20000, "Furniture"),
-            new Product("Wireless Mouse", 35000, 30000, "Accessories")
-        );
-        
-        // Add data rows
+                new Product("Widget Pro",  2450, 18375.00,  0.1240, LocalDate.of(2026, 1, 12), "A. Rahman", "Active"),
+                new Product("Gadget Max",  1820, 24934.00,  0.0875, LocalDate.of(2026, 2,  3), "J. Smith",  "Active"),
+                new Product("Contraption",  960,  9504.00, -0.0320, LocalDate.of(2026, 2, 21), "S. Ali",    "Review"),
+                new Product("Gizmo Lite",  3105,  6210.50,  0.2210, LocalDate.of(2026, 3,  5), "D. Wu",     "Active"),
+                new Product("Legacy Kit",   410,  2050.00, -0.1500, LocalDate.of(2024,11, 12), "R. Khan",   "Closed"));
+
+        // The 5-line core the README advertises — title / headers / zebra / freeze / filter
+        // all come from the builder. titleStyle() swaps the default centred-bold title for
+        // the navy bar the preview uses.
+        ReportBuilder.on(sh)
+                .title("Q3 Sales Report — Regional Breakdown")
+                .titleStyle(ExcelStyle.title())
+                .rowsFromBeans(products)
+                .zebraStripes(true)
+                .freezeHeader(true)
+                .autoFilter(true)
+                .columnWidth(1, 18).columnWidth(2, 10).columnWidth(3, 14)
+                .columnWidth(4, 12).columnWidth(5, 14).columnWidth(6, 14)
+                .columnWidth(7, 12)
+                .render();
+
+        // Per-cell tweaks ReportBuilder can't infer: growth colour tracks sign,
+        // status colour tracks category. Rows 3..7 (title=1, header=2).
         for (int i = 0; i < products.size(); i++) {
+            int r = i + 3;
             Product p = products.get(i);
-            int row = i + 2;
-            
-            sheet.cell(row, 1).setText(p.name);
-            sheet.cell(row, 2).setNumericValue(p.currentSales);
-            sheet.cell(row, 2).setNumberFormat("$#,##0.00");
-            sheet.cell(row, 3).setNumericValue(p.previousSales);
-            sheet.cell(row, 3).setNumberFormat("$#,##0.00");
-            sheet.cell(row, 4).setFormula(String.format("=(B%d-C%d)/C%d", row, row, row));
-            sheet.cell(row, 4).setNumberFormat("0.00%");
-            sheet.cell(row, 5).setText(p.category);
+            sh.cell(r, 4).applyStyle(growthStyle(p.growth));
+            sh.cell(r, 7).applyStyle(statusStyle(p.status));
         }
-        
-        // Add totals row
-        int lastRow = products.size() + 2;
-        sheet.cell(lastRow, 1).setText("Total");
-        sheet.cell(lastRow, 1).setFontStyle(true, false, false);
-        sheet.cell(lastRow, 2).setFormula(String.format("=SUM(B2:B%d)", lastRow-1));
-        sheet.cell(lastRow, 2).setNumberFormat("$#,##0.00");
-        sheet.cell(lastRow, 2).setFontStyle(true, false, false);
-        sheet.cell(lastRow, 3).setFormula(String.format("=SUM(C2:C%d)", lastRow-1));
-        sheet.cell(lastRow, 3).setNumberFormat("$#,##0.00");
-        sheet.cell(lastRow, 3).setFontStyle(true, false, false);
-        
-        // Format data section
-        sheet.cell(1, 1).setFullBorder("black");
-        sheet.cell(lastRow, 5).setFullBorder("black");
+
+        // Comment on the "Contraption" row explaining the Review flag.
+        sh.cell(5, 1).setComment(
+                "Margin slipped below threshold this quarter — flagged for review.",
+                "Q3 Review");
+
+        // Totals row — row 8. Growth here is always positive, so we pin it green.
+        int totalsRow = products.size() + 3;
+        sh.row(totalsRow).setValues(new Object[]{"TOTALS", 8745, 61073.50, 0.0501, null, "5 owners", "4 / 5"});
+        sh.row(totalsRow).applyStyle(ExcelStyle.totals(), 1, 8);
+        sh.cell(totalsRow, 2).setNumberFormat("#,##0");
+        sh.cell(totalsRow, 3).setNumberFormat("$#,##0.00");
+        sh.cell(totalsRow, 4).setNumberFormat("\"▲ \"0.00%;\"▼ \"0.00%");
+        sh.cell(totalsRow, 4).setFontColor("#1a7f37");
+        sh.cell(totalsRow, 5).setText("—");
+        sh.cell(totalsRow, 7).setHorizontalAlignment("CENTER");
     }
-    
-    private static void createChartsSheet(ExcelWorkSheet sheet, ExcelWorkSheet data) {
-        // Title
-        sheet.cell(1, 1).setText("Sales Analysis");
-        sheet.cell(1, 1).setFontStyle(true, false, false);
-        
-        // Add chart (Note: This is a placeholder as chart creation would require additional implementation)
-        sheet.cell(3, 1).setText("Sales by Product");
-        sheet.cell(3, 1).setFontStyle(true, false, false);
-        // Chart implementation would go here
-        
-        sheet.cell(3, 4).setText("Growth Analysis");
-        sheet.cell(3, 4).setFontStyle(true, false, false);
-        // Chart implementation would go here
+
+    private static ExcelStyle growthStyle(double growth) {
+        return ExcelStyle.builder()
+                .fontColor(growth >= 0 ? "#1a7f37" : "#cf222e")
+                .bold(true)
+                .horizontalAlignment("RIGHT")
+                .numberFormat("\"▲ \"0.00%;\"▼ \"0.00%")
+                .build();
     }
-    
-    private static class Product {
-        final String name;
-        final double currentSales;
-        final double previousSales;
-        final String category;
-        
-        Product(String name, double currentSales, double previousSales, String category) {
-            this.name = name;
-            this.currentSales = currentSales;
-            this.previousSales = previousSales;
-            this.category = category;
+
+    private static ExcelStyle statusStyle(String status) {
+        switch (status) {
+            case "Active": return ExcelStyle.statusActive();
+            case "Review": return ExcelStyle.statusReview();
+            case "Closed": return ExcelStyle.statusClosed();
+            default:       return ExcelStyle.builder().horizontalAlignment("CENTER").build();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <!-- ───────── coordinates ───────── -->
     <groupId>solutions.bismi.excel</groupId>
     <artifactId>excel</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <name>Excel</name>
     <description>Easy-to-use Excel wrapper for Apache POI</description>
@@ -133,6 +133,26 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+                <configuration>
+                    <!--
+                        Exclude demo/example sources and documentation-only enums from coverage:
+                        - examples/ is compiled as a source root so the snippets in README stay
+                          valid, but it is sample code, not library code.
+                        - ExcelCell$NamedColor is an enum that exists purely for IDE
+                          autocomplete and Javadoc links; it has no executable call sites.
+                    -->
+                    <excludes>
+                        <exclude>SalesReport*</exclude>
+                        <exclude>DashboardExample*</exclude>
+                        <exclude>InvoiceExample*</exclude>
+                        <exclude>EmployeeDirectoryExample*</exclude>
+                        <exclude>CollectionReportExample*</exclude>
+                        <exclude>KpiTilesExample*</exclude>
+                        <exclude>TitleAndContentExample*</exclude>
+                        <exclude>RowFromArrayExample*</exclude>
+                        <exclude>solutions/bismi/excel/ExcelCell$NamedColor.class</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -209,17 +229,10 @@
         </plugins>
     </build>
 
-    <!-- ───────── GPG profile (activates when env var present) ───────── -->
-    <profiles>
-        <profile>
-            <id>gpg</id>
-            <activation>
-                <property><name>env.GPG_PASSPHRASE</name></property>
-            </activation>
-            <properties>
-                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-            </properties>
-        </profile>
-    </profiles>
+    <!--
+        GPG signing uses the MAVEN_GPG_PASSPHRASE env variable read natively
+        by maven-gpg-plugin 3.2+. The older <gpg.passphrase> Maven property is
+        deprecated (leaks via process args) so we don't set it.
+    -->
 
 </project>

--- a/src/main/java/solutions/bismi/excel/ExcelCell.java
+++ b/src/main/java/solutions/bismi/excel/ExcelCell.java
@@ -12,6 +12,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellUtil;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -257,11 +261,11 @@ public class ExcelCell {
                 (byte) Integer.parseInt(hexColor.substring(2, 4), 16),
                 (byte) Integer.parseInt(hexColor.substring(4, 6), 16)
             };
-            org.apache.poi.xssf.usermodel.XSSFFont xssfFont = (org.apache.poi.xssf.usermodel.XSSFFont) newFont;
-            xssfFont.setColor(new org.apache.poi.xssf.usermodel.XSSFColor(rgb, null));
+            XSSFFont xssfFont = (XSSFFont) newFont;
+            xssfFont.setColor(new XSSFColor(rgb, null));
         } catch (Exception e) {
             log.error("Error parsing hex color: {}", e.getMessage());
-            newFont.setColor(org.apache.poi.ss.usermodel.IndexedColors.BLACK.getIndex());
+            newFont.setColor(IndexedColors.BLACK.getIndex());
         }
     }
 
@@ -305,7 +309,7 @@ public class ExcelCell {
 
             if (fontColor != null && fontColor.startsWith("#")) {
                 String hexColor = fontColor.substring(1);
-                if (workbook instanceof org.apache.poi.xssf.usermodel.XSSFWorkbook) {
+                if (workbook instanceof XSSFWorkbook) {
                     // XLSX: true hex color
                     setHexColor(hexColor, newFont);
                 } else {
@@ -381,7 +385,7 @@ public class ExcelCell {
 
             if (fillColor != null && fillColor.startsWith("#") && fillColor.length() >= 7) {
                 String hex = fillColor.substring(1);
-                if (workbook instanceof org.apache.poi.xssf.usermodel.XSSFWorkbook) {
+                if (workbook instanceof XSSFWorkbook) {
                     setXSSFHexFillColor(hex, newStyle);
                 } else {
                     setHSSFHexFillColor(hex, newStyle);
@@ -404,8 +408,8 @@ public class ExcelCell {
                 (byte) Integer.parseInt(hex.substring(2, 4), 16),
                 (byte) Integer.parseInt(hex.substring(4, 6), 16)
             };
-            org.apache.poi.xssf.usermodel.XSSFCellStyle xs = (org.apache.poi.xssf.usermodel.XSSFCellStyle) style;
-            xs.setFillForegroundColor(new org.apache.poi.xssf.usermodel.XSSFColor(rgb, null));
+            XSSFCellStyle xs = (XSSFCellStyle) style;
+            xs.setFillForegroundColor(new XSSFColor(rgb, null));
         } catch (Exception e) {
             log.error("Error parsing hex fill color: {}", e.getMessage());
             style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
@@ -532,9 +536,13 @@ public class ExcelCell {
     }
 
     /**
-     * Adds a medium-weight border (all four sides) around the cell.
+     * Adds a medium-weight border (all four sides) around the cell. Accepts a
+     * {@linkplain NamedColor named colour} or a hex code ({@code "#RRGGBB"}).
+     * Hex is rendered exactly on {@code .xlsx}; on {@code .xls} (HSSF) it falls
+     * back to the closest indexed colour — mirroring how {@link #setFillColor}
+     * and {@link #setFontColor} behave, so a single hex palette works for both.
      *
-     * @param borderColor colour of the border (named or hex for XLSX)
+     * @param borderColor named or hex colour
      * @return this cell for chaining
      */
     public ExcelCell setFullBorder(String borderColor) {
@@ -545,23 +553,55 @@ public class ExcelCell {
             CellStyle newStyle = workbook.createCellStyle();
             newStyle.cloneStyleFrom(originalStyle);
 
-            short colorCode = Common.getColorCode(borderColor);
-
             newStyle.setBorderLeft(BorderStyle.MEDIUM);
             newStyle.setBorderRight(BorderStyle.MEDIUM);
             newStyle.setBorderTop(BorderStyle.MEDIUM);
             newStyle.setBorderBottom(BorderStyle.MEDIUM);
 
-            newStyle.setLeftBorderColor(colorCode);
-            newStyle.setRightBorderColor(colorCode);
-            newStyle.setTopBorderColor(colorCode);
-            newStyle.setBottomBorderColor(colorCode);
+            boolean isHex = borderColor != null
+                    && borderColor.startsWith("#")
+                    && borderColor.length() >= 7;
+
+            if (isHex && workbook instanceof XSSFWorkbook) {
+                // XLSX: apply the exact hex on all four sides via XSSFColor.
+                XSSFColor color = hexToXSSFColor(borderColor.substring(1));
+                XSSFCellStyle xs = (XSSFCellStyle) newStyle;
+                xs.setLeftBorderColor(color);
+                xs.setRightBorderColor(color);
+                xs.setTopBorderColor(color);
+                xs.setBottomBorderColor(color);
+            } else {
+                // HSSF (hex → nearest indexed) or a named colour.
+                short colorCode = isHex
+                        ? closestIndexedForHex(borderColor.substring(1))
+                        : Common.getColorCode(borderColor);
+                newStyle.setLeftBorderColor(colorCode);
+                newStyle.setRightBorderColor(colorCode);
+                newStyle.setTopBorderColor(colorCode);
+                newStyle.setBottomBorderColor(colorCode);
+            }
 
             cCell.setCellStyle(newStyle);
         } catch (Exception e) {
             log.error("Error in setting border: {}", e.getMessage());
         }
         return this;
+    }
+
+    private XSSFColor hexToXSSFColor(String hex) {
+        byte[] rgb = new byte[] {
+                (byte) Integer.parseInt(hex.substring(0, 2), 16),
+                (byte) Integer.parseInt(hex.substring(2, 4), 16),
+                (byte) Integer.parseInt(hex.substring(4, 6), 16)
+        };
+        return new XSSFColor(rgb, null);
+    }
+
+    private short closestIndexedForHex(String hex) {
+        int r = Integer.parseInt(hex.substring(0, 2), 16);
+        int g = Integer.parseInt(hex.substring(2, 4), 16);
+        int b = Integer.parseInt(hex.substring(4, 6), 16);
+        return getClosestIndexedColor(r, g, b);
     }
 
 

--- a/src/main/java/solutions/bismi/excel/ExcelStyle.java
+++ b/src/main/java/solutions/bismi/excel/ExcelStyle.java
@@ -142,4 +142,63 @@ public final class ExcelStyle {
     public static ExcelStyle date() {
         return builder().numberFormat("dd-MMM-yyyy").build();
     }
+
+    /**
+     * Navy merged-title bar — white bold centred text on {@code #0f2d5c}. Pairs
+     * with {@link #header()} for the column headers below it.
+     */
+    public static ExcelStyle title() {
+        return builder()
+                .fillColor("#0f2d5c")
+                .fontColor("white")
+                .bold(true)
+                .horizontalAlignment("CENTER")
+                .build();
+    }
+
+    /**
+     * Totals row — pale-blue fill with dark-navy bold text and blue border.
+     * Designed to sit directly under the data rows produced by {@link ReportBuilder}.
+     */
+    public static ExcelStyle totals() {
+        return builder()
+                .fillColor("#e6eefc")
+                .fontColor("#0f2d5c")
+                .bold(true)
+                .fullBorder("#2d6cdf")
+                .build();
+    }
+
+    /** Status pill — green fill, green bold text (e.g. {@code Active}, {@code OK}). */
+    public static ExcelStyle statusActive() {
+        return statusPill("#d1f4dc", "#1a7f37");
+    }
+
+    /** Status pill — amber fill, amber bold text (e.g. {@code Review}, {@code Pending}). */
+    public static ExcelStyle statusReview() {
+        return statusPill("#fff1e5", "#bc4c00");
+    }
+
+    /** Status pill — red fill, red bold text (e.g. {@code Closed}, {@code Error}). */
+    public static ExcelStyle statusClosed() {
+        return statusPill("#ffebe9", "#cf222e");
+    }
+
+    /**
+     * Builds a status-pill style from any two hex colours. {@code fillHex} is the
+     * pastel fill; {@code textHex} is used for both the bold font and the border.
+     *
+     * <pre>
+     * cell.applyStyle(ExcelStyle.statusPill("#e0e7ff", "#1d4ed8"));  // custom blue
+     * </pre>
+     */
+    public static ExcelStyle statusPill(String fillHex, String textHex) {
+        return builder()
+                .fillColor(fillHex)
+                .fontColor(textHex)
+                .bold(true)
+                .horizontalAlignment("CENTER")
+                .fullBorder(textHex)
+                .build();
+    }
 }

--- a/src/main/java/solutions/bismi/excel/ExcelWorkSheet.java
+++ b/src/main/java/solutions/bismi/excel/ExcelWorkSheet.java
@@ -117,8 +117,7 @@ public class ExcelWorkSheet {
 
 
     /**
-     * @param strArrSheets
-     * @return
+     * @param strArrSheets names of the sheets to create
      */
     protected void addSheets(String[] strArrSheets) {
         try {

--- a/src/test/java/solutions/bismi/excel/ExcelStyleTest.java
+++ b/src/test/java/solutions/bismi/excel/ExcelStyleTest.java
@@ -39,12 +39,65 @@ class ExcelStyleTest {
     @Test
     void bPresetsAreNonNull() {
         Assertions.assertNotNull(ExcelStyle.header());
+        Assertions.assertNotNull(ExcelStyle.greyHeader());
         Assertions.assertNotNull(ExcelStyle.zebraStripe());
         Assertions.assertNotNull(ExcelStyle.currency());
         Assertions.assertNotNull(ExcelStyle.percent());
         Assertions.assertNotNull(ExcelStyle.date());
         Assertions.assertEquals("$#,##0.00", ExcelStyle.currency().getNumberFormat());
         Assertions.assertEquals("0.00%", ExcelStyle.percent().getNumberFormat());
+    }
+
+    @Test
+    void bReportPresetsCarryExpectedColours() {
+        ExcelStyle title = ExcelStyle.title();
+        Assertions.assertEquals("#0f2d5c", title.getFillColor());
+        Assertions.assertEquals("white",   title.getFontColor());
+        Assertions.assertTrue(title.isBold());
+        Assertions.assertEquals("CENTER",  title.getHorizontalAlignment());
+
+        ExcelStyle totals = ExcelStyle.totals();
+        Assertions.assertEquals("#e6eefc", totals.getFillColor());
+        Assertions.assertEquals("#0f2d5c", totals.getFontColor());
+        Assertions.assertEquals("#2d6cdf", totals.getBorderColor());
+        Assertions.assertTrue(totals.isBold());
+
+        // Status pills — fill, font, border all set; bold; centred.
+        ExcelStyle active = ExcelStyle.statusActive();
+        Assertions.assertEquals("#d1f4dc", active.getFillColor());
+        Assertions.assertEquals("#1a7f37", active.getFontColor());
+        Assertions.assertEquals("#1a7f37", active.getBorderColor());
+
+        Assertions.assertEquals("#bc4c00", ExcelStyle.statusReview().getFontColor());
+        Assertions.assertEquals("#cf222e", ExcelStyle.statusClosed().getFontColor());
+
+        // Custom pill via statusPill(fill, text)
+        ExcelStyle custom = ExcelStyle.statusPill("#e0e7ff", "#1d4ed8");
+        Assertions.assertEquals("#e0e7ff", custom.getFillColor());
+        Assertions.assertEquals("#1d4ed8", custom.getBorderColor());
+    }
+
+    @Test
+    void fHexBorderColourRendersOnXlsx() {
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/styleHexBorder.xlsx");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        sh.cell(1, 1).setValue("Totals").applyStyle(ExcelStyle.totals());
+        sh.saveWorkBook();
+
+        Cell raw = wb.getWb().getSheet("S").getRow(0).getCell(0);
+        org.apache.poi.xssf.usermodel.XSSFCellStyle xs =
+                (org.apache.poi.xssf.usermodel.XSSFCellStyle) raw.getCellStyle();
+        org.apache.poi.xssf.usermodel.XSSFColor topBorder = xs.getTopBorderXSSFColor();
+        Assertions.assertNotNull(topBorder);
+        byte[] rgb = topBorder.getRGB();
+        // #2d6cdf → 0x2D, 0x6C, 0xDF (bytes may be sign-extended)
+        Assertions.assertEquals((byte) 0x2D, rgb[0]);
+        Assertions.assertEquals((byte) 0x6C, rgb[1]);
+        Assertions.assertEquals((byte) 0xDF, rgb[2]);
+
+        app.closeAllWorkBooks();
     }
 
     @Test
@@ -82,6 +135,30 @@ class ExcelStyleTest {
         ExcelWorkSheet sh = wb.addSheet("S");
         Assertions.assertDoesNotThrow(() -> sh.cell(1, 1).applyStyle(null));
         Assertions.assertDoesNotThrow(() -> sh.row(1).applyStyle(null));
+        app.closeAllWorkBooks();
+    }
+
+    @Test
+    void gHexBorderColourFallsBackOnXls() {
+        // On .xls (HSSF) there is no true-colour palette for borders. The library
+        // must fall back to the closest indexed colour instead of silently writing
+        // AUTOMATIC (which is what Common.getColorCode returns for an unknown name).
+        ExcelApplication app = new ExcelApplication();
+        ExcelWorkBook wb = app.createWorkBook("./resources/testdata/styleHexBorder.xls");
+        ExcelWorkSheet sh = wb.addSheet("S");
+
+        sh.cell(1, 1).setValue("Totals").applyStyle(ExcelStyle.totals());
+        sh.saveWorkBook();
+
+        Cell raw = wb.getWb().getSheet("S").getRow(0).getCell(0);
+        CellStyle cs = raw.getCellStyle();
+        short indexed = cs.getTopBorderColor();
+        // AUTOMATIC (0x40) is the "no colour picked" sentinel — returned by
+        // Common.getColorCode for unknown names. A working nearest-indexed
+        // fallback always picks a real palette index.
+        Assertions.assertNotEquals((short) 0x40, indexed,
+                "hex border on .xls fell through to AUTOMATIC — nearest-indexed fallback missing");
+
         app.closeAllWorkBooks();
     }
 }


### PR DESCRIPTION
Three stacked commits, each self-contained. Summary:

## 1.3.0 — SalesReport parity with report-preview.svg
New `ExcelStyle` presets: `title()` (navy merged title bar), `totals()` (pale-blue totals row), and `statusActive|Review|Closed` + the general `statusPill(fill, text)` builder. Extended `setFullBorder` to take hex colours — exact `XSSFColor` on `.xlsx`, nearest-indexed fallback on `.xls`, symmetric with `setFillColor` / `setFontColor`. Rewrote `examples/SalesReport.java` to produce the preview's 7-column bean-driven report with sign-aware growth arrows, coloured status pills, a comment on the Contraption row, and a bordered totals row. Output path aligned with the other examples. XSSF/HSSF references in `ExcelCell` promoted to proper imports.

## CI hygiene — clear warnings from every build
- Bump `actions/checkout` and `actions/setup-java` to `@v5`, `codecov/codecov-action` to `@v6` (Node 20 → Node 24).
- Drop the stray empty `@return` on `ExcelWorkSheet#addSheets` (void return type).
- Switch GPG signing to `MAVEN_GPG_PASSPHRASE` env var — `maven-gpg-plugin` 3.2+ reads it natively, replacing the deprecated `gpg.passphrase` Maven property. Sonatype auth (`<server id=\"central\">`) is unchanged so publish keeps working.

## Badge + coverage fix
- The Snyk per-repo badge endpoint now returns \`HTTP 410 Gone\`; replaced with an OpenSSF Scorecard badge.
- JaCoCo was conflating the \`examples/\` source root (added by build-helper so README snippets compile) and the documentation-only \`ExcelCell\$NamedColor\` enum with library code, dragging reported coverage to 63%. Added an \`<excludes>\` block so coverage now reflects library code only — currently 84%.

## Test plan
- [x] \`mvn verify -Dgpg.skip=true\` — 97 tests green locally.
- [x] Generated \`./resources/testdata/salesReport.xlsx\`, unzipped, verified every SVG colour (fills, font colours, borders) is present in \`xl/styles.xml\`; mergeCell A1:G1, autoFilter A2:G2, and comment on A5 are emitted correctly.
- [ ] CI build on PR (validates workflow bumps + GPG env-var signing path).
- [ ] Codecov shows the new coverage baseline on the PR check.